### PR TITLE
ci: add Bun smoke job for runtime compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,25 @@ jobs:
 
       - name: Package readiness
         run: npm run ci:package
+
+  bun-smoke:
+    name: Bun smoke (ubuntu)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Node dependencies
+        run: bun install
+
+      - name: CLI version (cold-start under Bun)
+        run: bun bin/lumina.js --version --no-update
+
+      - name: End-to-end install under Bun
+        run: bun run dev:sandbox -- --yes --packs core


### PR DESCRIPTION
## Summary

Adds a `bun-smoke` CI job that exercises the CLI under the Bun runtime, addressing the **CI/CD Hardening** item in the v1.x roadmap (Bun coverage; Node 22 was already in matrix).

## What this does

- New parallel job `bun-smoke` on `ubuntu-latest`
- `bun install` → `bun bin/lumina.js --version --no-update` → `bun run dev:sandbox -- --yes --packs core`
- `continue-on-error: true` so Bun-specific issues do not block Node-based releases while compatibility is being established

## What this does NOT do

- Does **not** run unit tests under Bun. `npm scripts` hard-code `node --test` so `bun run test:installer` would still exec Node — the test would be dishonest. The end-to-end sandbox install (which uses `process.execPath` to spawn the CLI) genuinely exercises Bun's runtime.
- Does **not** add Bun to Windows/macOS — Bun's Windows support is still flaky and most users invoke via Node.

## Rationale for `continue-on-error`

First run is exploratory — we expect to discover at least one Bun incompatibility (e.g. `fd.datasync()`, symlink ladder behavior, `os.replace` semantics). Once we know what (if anything) breaks, a follow-up PR can either fix the incompat or remove the flag.

## Test plan

- [x] YAML validates (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [x] Existing Node test suite still passes (`npm run test:installer`)
- [ ] CI run shows `bun-smoke` job executing (pass or fail — surfaces compat status)
- [ ] If fails: follow-up PR with documented Bun gaps