### PR TITLE
fix(cli): align exit codes + pin public flag contract (Stability Lock PR-1)

### DIFF
--- a/bin/lumina.flags.test.js
+++ b/bin/lumina.flags.test.js
@@ -1,0 +1,183 @@
+/**
+ * Pin the public CLI contract: flag names and exit code matrix.
+ *
+ * Goal: any rename or removal of a STABLE flag, or any drift in the
+ * exit code mapping, must fail this test before reaching users.
+ *
+ * Source of truth: docs/planning-artifacts/audits/cli-contract-audit.md
+ * (and the `--help` text in bin/lumina.js).
+ *
+ * INTERNAL/hidden flags (--cwd, --project-name) are intentionally NOT
+ * pinned here — those have no public contract and may change.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = dirname(__filename);
+const CLI = join(__dirname, 'lumina.js');
+
+function runCli(args, opts = {}) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf8',
+    timeout: 10_000,
+    env: { ...process.env, LUMINA_NO_UPDATE_CHECK: '1', NO_COLOR: '1' },
+    ...opts,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// STABLE flag enumeration — keep in sync with audit doc.
+// Each entry: flag name as a user would type it on the command line.
+// ---------------------------------------------------------------------------
+const STABLE_GLOBAL = [
+  '--directory',
+  '-y, --yes',
+  '--no-update',
+  '--re-link',
+];
+
+const STABLE_INSTALL = [
+  '--packs',
+  '--ide-targets',
+  '--communication-language',
+  '--document-output-language',
+];
+
+const STABLE_DISCOVER_RUN = [
+  '--config',
+  '--schedule',
+  '--source',
+  '--limit',
+  '--dry-run',
+  '--json',
+];
+
+// ---------------------------------------------------------------------------
+// Help text contains all stable flag names
+// ---------------------------------------------------------------------------
+
+test('top-level --help advertises every STABLE global flag', () => {
+  const r = runCli(['--help']);
+  assert.equal(r.status, 0, `--help should exit 0; got ${r.status}`);
+  for (const flag of STABLE_GLOBAL) {
+    assert.ok(r.stdout.includes(flag), `--help missing global flag: ${flag}`);
+  }
+});
+
+test('install --help advertises every STABLE install flag', () => {
+  const r = runCli(['install', '--help']);
+  assert.equal(r.status, 0);
+  for (const flag of STABLE_INSTALL) {
+    assert.ok(r.stdout.includes(flag), `install --help missing flag: ${flag}`);
+  }
+});
+
+test('discover run --help advertises every STABLE discover flag', () => {
+  const r = runCli(['discover', 'run', '--help']);
+  assert.equal(r.status, 0);
+  for (const flag of STABLE_DISCOVER_RUN) {
+    assert.ok(r.stdout.includes(flag), `discover run --help missing flag: ${flag}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Help text describes the documented exit code contract
+// ---------------------------------------------------------------------------
+
+test('--help exit code section documents codes 0/1/2/3', () => {
+  const r = runCli(['--help']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /Exit codes:/);
+  assert.match(r.stdout, /^\s*0\s+success/m);
+  assert.match(r.stdout, /^\s*1\s+user error/m);
+  assert.match(r.stdout, /^\s*2\s+filesystem.*safety/m);
+  assert.match(r.stdout, /^\s*3\s+internal.*network/m);
+});
+
+// ---------------------------------------------------------------------------
+// Exit code matrix
+// ---------------------------------------------------------------------------
+
+test('exit 0 — --version', () => {
+  const r = runCli(['--version']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /^\d+\.\d+\.\d+/);
+});
+
+test('exit 0 — --help', () => {
+  assert.equal(runCli(['--help']).status, 0);
+});
+
+test('exit 1 — unknown flag', () => {
+  const r = runCli(['install', '--this-flag-does-not-exist']);
+  assert.equal(r.status, 1, `unknown flag should exit 1; got ${r.status}`);
+});
+
+test('exit 1 — unknown subcommand', () => {
+  const r = runCli(['this-command-does-not-exist']);
+  assert.equal(r.status, 1);
+});
+
+test('exit 2/3 — install fails on a non-writable target with fs/io error', () => {
+  // Pin: filesystem-class errors exit 2 or 3, never 1 (user error).
+  // Use a path under a regular file so mkdir resolves to ENOTDIR/EEXIST.
+  const tmp = mkdtempSync(join(tmpdir(), 'lumina-test-'));
+  try {
+    // Create a file at the parent path so any subdir creation under it fails.
+    const blocker = join(tmp, 'blocker');
+    writeFileSync(blocker, '');
+    const target = join(blocker, 'inside-a-file');
+    const r = runCli(['install', '--yes', '--directory', target], { cwd: tmp });
+    assert.notEqual(r.status, 0, 'install into invalid path must not succeed');
+    assert.notEqual(r.status, 1, 'fs error must not collapse to "user error"');
+    assert.ok([2, 3].includes(r.status), `expected 2 or 3; got ${r.status}\nstderr: ${r.stderr.slice(0, 300)}`);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Backward-compat alias still functional (will be deprecated in v2 per
+// owner decision, but for v1.x must continue to work as alias for --directory).
+// ---------------------------------------------------------------------------
+
+test('--cwd remains accepted as backward-compat alias for --directory', () => {
+  // Driving install through to completion would require a sandbox; the cheap
+  // test here is that commander does not reject the flag with exit 1.
+  const tmp = mkdtempSync(join(tmpdir(), 'lumina-test-'));
+  const target = join(tmp, 'sandbox');
+  mkdirSync(target);
+  try {
+    const r = runCli(['uninstall', '--cwd', target, '--yes'], { cwd: tmp });
+    // No installation in `target`, so command may fail — but NOT with
+    // exit 1 ("unknown flag" shape from commander).
+    assert.notEqual(r.status, null, 'process must terminate (timeout?)');
+    assert.ok(
+      !/unknown option/i.test(r.stderr),
+      `--cwd should be accepted; got stderr: ${r.stderr.slice(0, 200)}`,
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Environment variable contract
+// ---------------------------------------------------------------------------
+
+test('LUMINA_NO_UPDATE_CHECK=1 suppresses update banner on --version', () => {
+  const r = spawnSync(process.execPath, [CLI, '--version'], {
+    encoding: 'utf8',
+    timeout: 10_000,
+    env: { ...process.env, LUMINA_NO_UPDATE_CHECK: '1', NO_COLOR: '1' },
+  });
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stdout, /Update available/i);
+});

--- a/bin/lumina.js
+++ b/bin/lumina.js
@@ -91,7 +91,7 @@ function exitCodeFor(err, defaultCode = 1) {
   if (err.code === 'EACCES' || err.code === 'EPERM') return 2;
   if (err.code === 2) return 2;
   if (err.code === 3) return 3;
-  if (typeof err.code === 'string' && /^E[A-Z]+$/.test(err.code)) return 3;
+  if (typeof err.code === 'string' && err.code.startsWith('E')) return 3;
   return defaultCode;
 }
 

--- a/bin/lumina.js
+++ b/bin/lumina.js
@@ -76,6 +76,25 @@ if (handledVersion) process.exit(0);
 const { Command, Option } = await import('commander');
 const program = new Command();
 
+// ---------------------------------------------------------------------------
+// Exit code contract (see docs/planning-artifacts/audits/cli-contract-audit.md
+// and `--help` text below). Caught errors map as follows:
+//   - RangeError (from safePath)        → 2 (path safety)
+//   - err.code in {EACCES, EPERM}        → 2 (filesystem perms)
+//   - err.code === 2 / err.code === 3    → preserved
+//   - other string fs codes (E*)         → 3 (internal/io: ENOENT, EBUSY, EIO,
+//                                            EROFS, ENOSPC, ENOTDIR, …)
+//   - everything else                    → 1 (user error)
+// ---------------------------------------------------------------------------
+function exitCodeFor(err, defaultCode = 1) {
+  if (err instanceof RangeError) return 2;
+  if (err.code === 'EACCES' || err.code === 'EPERM') return 2;
+  if (err.code === 2) return 2;
+  if (err.code === 3) return 3;
+  if (typeof err.code === 'string' && /^E[A-Z]+$/.test(err.code)) return 3;
+  return defaultCode;
+}
+
 program
   .name('lumina')
   .description('Lumina Wiki — domain-agnostic, multi-IDE wiki scaffolder')
@@ -84,8 +103,8 @@ program
 Exit codes:
   0  success
   1  user error (bad flag, missing prereq)
-  2  filesystem error (permission denied, path outside cwd)
-  3  upgrade incompatibility (manifest references unknown pack)
+  2  filesystem / safety (permission denied, path outside cwd, unknown pack slug)
+  3  internal / network (atomicWrite failure, 5xx, upgrade incompatibility, lint catastrophic)
 
 Flags applicable to all commands:
   --directory <path>  installation directory (defaults to current directory)
@@ -169,11 +188,9 @@ program
     } catch (err) {
       // Top-level catch: locale may not be resolved yet (pre-loadLocale path).
       // Error strings kept as EN literals — machine-readable, intentionally exempt.
-      const isPermError  = err.code === 'EACCES' || err.code === 'EPERM';
-      const isRangeError = err instanceof RangeError;
       console.error(`[error] ${err.message}`);
       if (process.env.DEBUG) console.error(err.stack);
-      process.exit(isPermError || isRangeError || err.code === 2 ? 2 : 1);
+      process.exit(exitCodeFor(err));
     }
   });
 
@@ -200,7 +217,7 @@ program
     } catch (err) {
       console.error(`[error] ${err.message}`);
       if (process.env.DEBUG) console.error(err.stack);
-      process.exit(2);
+      process.exit(exitCodeFor(err));
     }
   });
 
@@ -235,7 +252,9 @@ discover
     } catch (err) {
       console.error(`[error] ${err.message}`);
       if (process.env.DEBUG) console.error(err.stack);
-      process.exit(err.code === 2 ? 2 : 3);
+      // Unhandled exceptions from discover-runner are by definition not user
+      // errors (main() handles those), so default unknown → 3 (internal).
+      process.exit(exitCodeFor(err, 3));
     }
   });
 

--- a/docs/planning-artifacts/audits/cli-contract-audit.md
+++ b/docs/planning-artifacts/audits/cli-contract-audit.md
@@ -1,0 +1,145 @@
+---
+date: '2026-05-06'
+type: 'audit'
+status: 'draft'
+related-roadmap: 'Stability Lock (Near-term)'
+---
+
+# CLI Contract Audit
+
+Source review for **Stability Lock** roadmap item: enumerate current CLI surface, identify inconsistencies, propose stability classification.
+
+## Scope
+
+Files reviewed:
+- `bin/lumina.js` (entry point, commander setup)
+- `src/installer/commands.js`, `src/installer/prompts.js` (install/uninstall paths)
+- `src/scripts/wiki.mjs`, `src/scripts/lint.mjs`, `src/scripts/reset.mjs`, `src/scripts/discover-runner.mjs`
+
+## CLI surface (current)
+
+### Subcommands
+
+`install`, `uninstall`, `discover run`, top-level `--version`/`-v`/`--help`/`-h`.
+
+### Flags — proposed classification
+
+#### Global (all commands)
+
+| Flag | State | Proposal |
+|---|---|---|
+| `--directory <path>` | public, documented | **STABLE** |
+| `--cwd <path>` | hidden alias (backward-compat) | **DEPRECATE** — emit warning, remove at v2.0 |
+| `-y, --yes` | public | **STABLE** |
+| `--no-update` | public | **STABLE** |
+| `--re-link` | public | **STABLE** |
+
+#### `install`-only
+
+| Flag | State | Proposal |
+|---|---|---|
+| `--packs <list>` | public | **STABLE** |
+| `--ide-targets <list>` | public | **STABLE** |
+| `--project-name <name>` | hidden | **INTERNAL** (keep hidden, no contract) |
+| `--communication-language <lang>` | public | **STABLE** |
+| `--document-output-language <lang>` | public | **STABLE** |
+
+#### `discover run`-only
+
+`--config`, `--schedule` (manual\|daily\|weekly\|monthly), `--source` (arxiv\|s2), `--limit`, `--dry-run`, `--json` — all proposed **STABLE**.
+
+#### Environment variables
+
+`LUMINA_NO_UPDATE_CHECK=1`, `DEBUG`, `NO_COLOR` — all proposed **STABLE**.
+
+## Exit code contract — proposed
+
+| Code | Meaning | Trigger examples |
+|---|---|---|
+| 0 | success | Operation completed |
+| 1 | user error | Bad flag, missing required arg, unknown command |
+| 2 | filesystem / safety | EACCES, EPERM, path traversal, unknown slug, missing required `--yes` in CI |
+| 3 | internal / network | atomicWrite mid-rename failure, network 5xx, upgrade incompatibility, lint catastrophic |
+| 130 _(or 4 — TBD)_ | user cancelled | Ctrl-C in interactive prompt |
+
+**Lint exception:** `lint.mjs` exits `1` to mean "unresolved findings" (eslint-style). This conflicts with global "1 = user error". Either:
+- (a) document as legitimate exception (`lint` is check-tool semantics), OR
+- (b) move lint findings to a new code (e.g. `5`).
+
+## Inconsistencies found
+
+### A. `--help` exit-code text narrower than reality
+
+`bin/lumina.js:78-83` reads:
+
+```
+3  upgrade incompatibility (manifest references unknown pack)
+```
+
+Reality: code 3 is also used by `discover run` for any non-2 error, by `lint.mjs` for internal errors, etc. CLAUDE.md already defines code 3 broadly ("internal / fs failure / 5xx network").
+
+**Fix (non-breaking):** broaden `--help` text to match.
+
+### B. `lint.mjs` exit 1 conflicts with global contract
+
+`src/scripts/lint.mjs:1316`:
+
+```js
+process.exit(hasUnresolved ? 1 : 0);
+```
+
+Code 1 in global contract = "user error". Here it means "lint found issues". Needs decision (see "Lint exception" above).
+
+### C. `install` error mapping loses signal
+
+`bin/lumina.js:170`:
+
+```js
+process.exit(isPermError || isRangeError || err.code === 2 ? 2 : 1);
+```
+
+`atomicWrite` failures mid-rename (ENOENT/EBUSY/EIO) fall to `1` (user error) — should be `3` (internal).
+
+**Fix (non-breaking):** add fs-error code branch → `3`.
+
+### D. `uninstall` always exits 2
+
+`bin/lumina.js:197`: any error during uninstall returns `2` regardless of cause. Same fix as C.
+
+### E. Ctrl-C exits 0 (silent success)
+
+`src/installer/prompts.js` × 7 sites:
+
+```js
+if (isCancel(...)) { cancel('Installation cancelled.'); process.exit(0); }
+```
+
+CI scripts cannot distinguish user-cancelled installs from successful installs. **This is a breaking change** to fix — needs owner decision on target code (130 SIGINT convention vs. new `4`).
+
+### F. Global opts redeclared per subcommand
+
+`bin/lumina.js:127-133`, `:181-184`: `install` and `uninstall` redeclare `--directory`/`--yes`/etc. instead of inheriting via `program.opts()`. Functional via merge fallback; internal hygiene only — out of scope for Stability Lock.
+
+### G. No tests pin the contract
+
+`bin/lumina.js` has no `.test.js` companion. Contract is unenforced — flag rename today = silent CI pass.
+
+**Fix:** add `bin/lumina.flags.test.js` covering:
+- Help output enumerates all STABLE flags by exact name
+- Exit code matrix (path traversal → 2, bad flag → 1, etc.)
+- `--cwd` emits deprecation warning (after deprecation lands)
+
+## Summary
+
+- **STABLE** flags: 14 (most already correct in usage)
+- **DEPRECATE**: 1 (`--cwd`)
+- **INTERNAL/hidden**: 1 (`--project-name`)
+- **Non-breaking fixes**: A, C, D, G
+- **Owner decision required**: B (lint exception) and E (cancellation exit — breaking)
+
+## Unresolved questions for owner
+
+1. **`--cwd` deprecation path:** emit warning in v1.x and remove at v2.0, or keep silent forever?
+2. **Cancellation exit code:** accept breaking change to 130 (SIGINT), introduce new code 4, or keep 0?
+3. **`lint` exit 1:** document as legitimate check-tool exception, or move findings to a new code (e.g. 5)?
+4. **`--project-name`:** promote to public flag or keep INTERNAL?

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "devDependencies": {},
   "scripts": {
     "test": "npm run test:installer",
-    "test:installer": "node --test src/installer/commands.test.js src/installer/fs.test.js src/installer/locales.test.js src/installer/manifest.test.js src/installer/prompts.test.js src/installer/readme-templates.test.js src/installer/template-engine.test.js src/installer/update-check.test.js",
+    "test:installer": "node --test bin/lumina.flags.test.js src/installer/commands.test.js src/installer/fs.test.js src/installer/locales.test.js src/installer/manifest.test.js src/installer/prompts.test.js src/installer/readme-templates.test.js src/installer/template-engine.test.js src/installer/update-check.test.js",
     "test:scripts": "node --test src/scripts/lint.test.mjs src/scripts/reset.test.mjs src/scripts/wiki.test.mjs src/scripts/discover-runner.test.mjs src/scripts/external-ids.test.mjs src/scripts/parse-ids.test.mjs src/scripts/merge-ids.test.mjs src/scripts/build-source.test.mjs src/scripts/wiki-yaml-object.test.mjs",
     "test:python": "python3 -m pytest src/tools/tests -q",
     "test:all": "npm run test:installer && npm run test:scripts && npm run test:python",


### PR DESCRIPTION
## Summary

PR-1 of the **Stability Lock** roadmap item, addressing decisions in issue #4.

Three commits, all non-breaking:

1. `docs(audit)` — adds `docs/planning-artifacts/audits/cli-contract-audit.md` as the source of truth (the reference doc the issue links to).
2. `fix(cli)` — aligns exit codes in `bin/lumina.js` with the documented contract.
3. `test(cli)` — adds `bin/lumina.flags.test.js` to pin flag names and exit code matrix.

## What this changes

### Exit code mapping (`bin/lumina.js`)

Single helper `exitCodeFor(err, defaultCode)` replaces three different inline mappings:

| Error shape | Was | Now |
|---|---|---|
| `RangeError` (safePath) | 2 ✓ | 2 |
| `err.code` ∈ {EACCES, EPERM} | 2 ✓ | 2 |
| `err.code === 2` | 2 ✓ | 2 |
| `err.code === 3` | varied | 3 |
| Other Node fs codes (ENOENT, EBUSY, EIO, EROFS, ENOSPC, ENOTDIR…) | **1** ✗ | **3** ✓ |
| Plain Error / unknown | 1 (or 3 in discover) | 1 (3 in discover) |

The previously-buggy mapping rolled atomicWrite/io failures into exit 1 ('user error'), losing diagnostic signal. CI scripts that condition on exit codes now get the documented behavior.

### `--help` text

Old: `3 upgrade incompatibility (manifest references unknown pack)`
New: `3 internal / network (atomicWrite failure, 5xx, upgrade incompatibility, lint catastrophic)`

Old: `2 filesystem error (permission denied, path outside cwd)`
New: `2 filesystem / safety (permission denied, path outside cwd, unknown pack slug)`

### Test pin

`bin/lumina.flags.test.js` (11 tests) spawns the CLI and asserts:
- All 14 STABLE flags appear in `--help` output for their scope
- `--help` renders the documented exit code section
- Exit code matrix: `--version`/`--help` → 0; unknown flag/subcommand → 1; install into invalid path → 2 or 3 (never 1)
- `--cwd` remains accepted (backward-compat alias)
- `LUMINA_NO_UPDATE_CHECK=1` suppresses update banner

Renaming any STABLE flag will now fail CI before reaching users.

## What this does NOT do (deferred to PR-2/3/4)

- **PR-2 (docs):** dedicated `docs/cli-contract.md` + README link.
- **PR-3 (deprecation):** explicit `[deprecated]` warning when `--cwd` is used.
- **PR-4 (breaking):** new exit code 4 = user-cancelled (Ctrl-C in prompts).

## Verification

- `npm run test:installer` — 11 new + all existing pass
- `npm run test:all` — 289 Python + scripts + installer all pass
- `npm run ci:idempotency` — clean (multilingual EN/VI/ZH all stable)
- `npm run ci:package` — clean (85 files; test file correctly excluded from publish)

Closes part of issue #4.