### PR TITLE
feat(cli): deprecate --cwd with stderr warning (Stability Lock PR-3)

### DIFF
--- a/bin/lumina.deprecations.test.js
+++ b/bin/lumina.deprecations.test.js
@@ -21,10 +21,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = dirname(__filename);
 const CLI = join(__dirname, 'lumina.js');
 
-function runCli(args) {
+function runCli(args, { timeout = 10_000 } = {}) {
   return spawnSync(process.execPath, [CLI, ...args], {
     encoding: 'utf8',
-    timeout: 10_000,
+    timeout,
     env: { ...process.env, LUMINA_NO_UPDATE_CHECK: '1', NO_COLOR: '1' },
   });
 }
@@ -64,6 +64,40 @@ test('--cwd is still functional (warn-but-work, not warn-and-break)', () => {
     // Exit 0 = uninstall succeeded; non-zero would mean the deprecation
     // accidentally broke the alias.
     assert.equal(r.status, 0, `uninstall via --cwd must still succeed; got status ${r.status}, stderr: ${r.stderr.slice(0, 300)}`);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('--cwd emits a deprecation warning on install subcommand', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'lumi-dep-'));
+  try {
+    // Install scaffolds many files; bump timeout. The preAction hook fires
+    // before the action body, so the warning is on stderr regardless of
+    // how long install takes.
+    const r = runCli(['install', '--cwd', tmp, '--yes'], { timeout: 60_000 });
+    assert.match(
+      r.stderr,
+      /\[deprecated\][^\n]*--cwd[^\n]*v2\.0/,
+      `expected deprecation warning on install stderr; got: ${r.stderr.slice(0, 300)}`,
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('global --cwd (before subcommand) also emits the warning', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'lumi-dep-'));
+  try {
+    // Pins the global-options branch: `lumina --cwd <path> uninstall`.
+    // Without this, a future refactor that only checks per-command opts
+    // would silently drop the warning for global-flag users.
+    const r = runCli(['--cwd', tmp, 'uninstall', '--yes']);
+    assert.match(
+      r.stderr,
+      /\[deprecated\][^\n]*--cwd[^\n]*v2\.0/,
+      `expected deprecation warning when --cwd is global; got: ${r.stderr.slice(0, 300)}`,
+    );
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/bin/lumina.deprecations.test.js
+++ b/bin/lumina.deprecations.test.js
@@ -1,0 +1,70 @@
+/**
+ * Pin deprecation warnings: deprecated flags must continue to function
+ * AND must emit a warning to stderr.
+ *
+ * Source of truth: docs/cli-contract.md.
+ *
+ * If you remove a deprecated flag entirely, that requires a major
+ * version bump and an entry in CHANGELOG.md — and a corresponding
+ * removal of the test below.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = dirname(__filename);
+const CLI = join(__dirname, 'lumina.js');
+
+function runCli(args) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf8',
+    timeout: 10_000,
+    env: { ...process.env, LUMINA_NO_UPDATE_CHECK: '1', NO_COLOR: '1' },
+  });
+}
+
+test('--cwd emits a deprecation warning to stderr', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'lumi-dep-'));
+  try {
+    const r = runCli(['uninstall', '--cwd', tmp, '--yes']);
+    assert.match(
+      r.stderr,
+      /\[deprecated\][^\n]*--cwd[^\n]*v2\.0/,
+      `expected deprecation warning on stderr; got: ${r.stderr.slice(0, 300)}`,
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('--directory does NOT emit a deprecation warning', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'lumi-dep-'));
+  try {
+    const r = runCli(['uninstall', '--directory', tmp, '--yes']);
+    assert.doesNotMatch(
+      r.stderr,
+      /\[deprecated\]/,
+      `--directory must not warn; got: ${r.stderr.slice(0, 300)}`,
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('--cwd is still functional (warn-but-work, not warn-and-break)', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'lumi-dep-'));
+  try {
+    const r = runCli(['uninstall', '--cwd', tmp, '--yes']);
+    // Exit 0 = uninstall succeeded; non-zero would mean the deprecation
+    // accidentally broke the alias.
+    assert.equal(r.status, 0, `uninstall via --cwd must still succeed; got status ${r.status}, stderr: ${r.stderr.slice(0, 300)}`);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/bin/lumina.js
+++ b/bin/lumina.js
@@ -77,8 +77,8 @@ const { Command, Option } = await import('commander');
 const program = new Command();
 
 // ---------------------------------------------------------------------------
-// Exit code contract (see docs/planning-artifacts/audits/cli-contract-audit.md
-// and `--help` text below). Caught errors map as follows:
+// Exit code contract (see docs/cli-contract.md and `--help` text below).
+// Caught errors map as follows:
 //   - RangeError (from safePath)        → 2 (path safety)
 //   - err.code in {EACCES, EPERM}        → 2 (filesystem perms)
 //   - err.code === 2 / err.code === 3    → preserved
@@ -93,6 +93,21 @@ function exitCodeFor(err, defaultCode = 1) {
   if (err.code === 3) return 3;
   if (typeof err.code === 'string' && err.code.startsWith('E')) return 3;
   return defaultCode;
+}
+
+// ---------------------------------------------------------------------------
+// Deprecation warnings — emitted to stderr once per invocation.
+// Source of truth: docs/cli-contract.md.
+// ---------------------------------------------------------------------------
+let _cwdWarned = false;
+function warnDeprecatedCwdIfUsed(cmdOpts, globalOpts) {
+  if (_cwdWarned) return;
+  if (cmdOpts.cwd != null || globalOpts.cwd != null) {
+    process.stderr.write(
+      '[deprecated] --cwd is deprecated and will be removed in v2.0. Use --directory instead.\n'
+    );
+    _cwdWarned = true;
+  }
 }
 
 program
@@ -163,6 +178,7 @@ program
   .option('--force-locale-switch', 'allow switching installer locale during upgrade')
   .action(async (cmdOpts) => {
     const globalOpts = program.opts();
+    warnDeprecatedCwdIfUsed(cmdOpts, globalOpts);
     const mergedDir      = cmdOpts.directory ?? cmdOpts.cwd ?? globalOpts.directory ?? globalOpts.cwd ?? process.cwd();
     const mergedYes      = cmdOpts.yes      ?? globalOpts.yes      ?? false;
     const mergedReLink   = cmdOpts.reLink   ?? globalOpts.reLink   ?? false;
@@ -205,6 +221,7 @@ program
   .option('-y, --yes', 'skip confirmation prompt')
   .action(async (cmdOpts) => {
     const globalOpts = program.opts();
+    warnDeprecatedCwdIfUsed(cmdOpts, globalOpts);
     const mergedDir = cmdOpts.directory ?? cmdOpts.cwd ?? globalOpts.directory ?? globalOpts.cwd ?? process.cwd();
     const mergedYes = cmdOpts.yes ?? globalOpts.yes ?? false;
 

--- a/bin/lumina.js
+++ b/bin/lumina.js
@@ -12,7 +12,7 @@
  *
  * Flags (all commands):
  *   --directory <path>  — installation directory (defaults to current directory)
- *   --cwd <path>        — backward-compat alias for --directory
+ *   --cwd <path>        — [deprecated] alias for --directory; removed in v2.0
  *   --yes, -y           — accept all defaults (non-interactive / CI)
  *   --no-update         — skip npm registry version check
  *   --re-link           — recompute symlink/junction/copy strategy
@@ -151,6 +151,13 @@ program
   .option('--no-update', 'skip npm registry version check')
   .option('--re-link', 'recompute symlink strategy from current platform capabilities');
 
+// Single source of truth for --cwd deprecation: fires once before any
+// subcommand action regardless of whether --cwd was passed globally or
+// per-command. New subcommands inherit this for free.
+program.hook('preAction', (_thisCommand, actionCommand) => {
+  warnDeprecatedCwdIfUsed(actionCommand.opts(), program.opts());
+});
+
 // ---------------------------------------------------------------------------
 // --version / -v — print immediately then do async update check
 // ---------------------------------------------------------------------------
@@ -178,7 +185,6 @@ program
   .option('--force-locale-switch', 'allow switching installer locale during upgrade')
   .action(async (cmdOpts) => {
     const globalOpts = program.opts();
-    warnDeprecatedCwdIfUsed(cmdOpts, globalOpts);
     const mergedDir      = cmdOpts.directory ?? cmdOpts.cwd ?? globalOpts.directory ?? globalOpts.cwd ?? process.cwd();
     const mergedYes      = cmdOpts.yes      ?? globalOpts.yes      ?? false;
     const mergedReLink   = cmdOpts.reLink   ?? globalOpts.reLink   ?? false;
@@ -221,7 +227,6 @@ program
   .option('-y, --yes', 'skip confirmation prompt')
   .action(async (cmdOpts) => {
     const globalOpts = program.opts();
-    warnDeprecatedCwdIfUsed(cmdOpts, globalOpts);
     const mergedDir = cmdOpts.directory ?? cmdOpts.cwd ?? globalOpts.directory ?? globalOpts.cwd ?? process.cwd();
     const mergedYes = cmdOpts.yes ?? globalOpts.yes ?? false;
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "devDependencies": {},
   "scripts": {
     "test": "npm run test:installer",
-    "test:installer": "node --test bin/lumina.flags.test.js src/installer/commands.test.js src/installer/fs.test.js src/installer/locales.test.js src/installer/manifest.test.js src/installer/prompts.test.js src/installer/readme-templates.test.js src/installer/template-engine.test.js src/installer/update-check.test.js",
+    "test:installer": "node --test bin/lumina.flags.test.js bin/lumina.deprecations.test.js src/installer/commands.test.js src/installer/fs.test.js src/installer/locales.test.js src/installer/manifest.test.js src/installer/prompts.test.js src/installer/readme-templates.test.js src/installer/template-engine.test.js src/installer/update-check.test.js",
     "test:scripts": "node --test src/scripts/lint.test.mjs src/scripts/reset.test.mjs src/scripts/wiki.test.mjs src/scripts/discover-runner.test.mjs src/scripts/external-ids.test.mjs src/scripts/parse-ids.test.mjs src/scripts/merge-ids.test.mjs src/scripts/build-source.test.mjs src/scripts/wiki-yaml-object.test.mjs",
     "test:python": "python3 -m pytest src/tools/tests -q",
     "test:all": "npm run test:installer && npm run test:scripts && npm run test:python",


### PR DESCRIPTION
## Summary

PR-3 of the **Stability Lock** roadmap item. Implements owner decision Q1 from issue #4: `--cwd` remains a functional alias throughout v1.x but emits a stderr warning announcing removal at v2.0.

## Behavior

```
$ lumina uninstall --cwd /tmp/foo --yes
[deprecated] --cwd is deprecated and will be removed in v2.0. Use --directory instead.
[done] Removed _lumina/
[done] Removed .agents/
[done] Uninstall complete. wiki/ and raw/ preserved.
```

```
$ lumina uninstall --directory /tmp/foo --yes
[done] Removed _lumina/
[done] Removed .agents/
[done] Uninstall complete. wiki/ and raw/ preserved.
```

## Implementation notes

- **Idempotent across handlers** — warning emits once per process via a module-level `_cwdWarned` flag. Prevents duplicate warnings when `--cwd` reaches both global and command-level option layers.
- **English literal** matching the existing top-level catch comment in `bin/lumina.js` (`Error strings kept as EN literals — machine-readable, intentionally exempt`). Localizing the deprecation warning would require ordering against `loadLocale()` which the catch path already documents as not yet resolved at this layer.
- **stderr-only** — does not contaminate stdout (preserves `--json` semantics for `discover run`, etc.).
- **No exit code change** — warn-and-continue, not warn-and-break.

## Test (`bin/lumina.deprecations.test.js`)

3 spawn-based cases pinning the contract:
- `--cwd` emits the deprecation warning
- `--directory` does NOT emit any deprecation warning
- `--cwd` is still functional (`uninstall --cwd <tmp> --yes` exits 0)

If the warning is accidentally removed before v2.0, CI fails. If the alias is broken under the warning, CI fails.

## Verification

- `npm run test:installer` — new + all existing pass
- `npm run ci:idempotency` — clean (multilingual EN/VI/ZH stable)

## Relationship to other PRs

| PR | Status | Relevance |
|---|---|---|
| #10 (PR-1) | Open | Independent — adds the underlying flag-pin test infrastructure |
| #11 (PR-2) | Open | Documents `--cwd` as DEPRECATED in `docs/cli-contract.md` |
| **#13 (this, PR-3)** | — | Implements the warning that PR-2 documents |
| PR-4 | TBD | Cancellation exit code 4 (separate, breaking change) |

This PR is independent at the diff level. If #11 lands first, the doc accurately describes runtime behavior. If this lands first, runtime is more conservative than the doc claims (still "warns") — both safe orderings.

## Test plan

- [x] Unit: 3 deprecation tests pass
- [x] Full installer test suite passes
- [x] Idempotency CI clean
- [ ] Owner verifies warning text wording is acceptable