### PR TITLE
feat(cli): introduce exit code 4 for user cancellation (Stability Lock PR-4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,5 +125,6 @@ The full list lives in `docs/project-context.md` §3. The ones most likely to bi
 - `1` user error (bad args)
 - `2` filesystem / path safety / unknown slug / missing `--yes`
 - `3` internal / fs failure / upgrade incompatibility / 5xx network
+- `4` user cancelled (Ctrl-C in interactive prompt or declined confirm)
 
 `EACCES` / `EPERM` / `RangeError` (from `safePath`) all map to exit 2 at `bin/lumina.js`.

--- a/bin/lumina.cancel.test.js
+++ b/bin/lumina.cancel.test.js
@@ -1,0 +1,58 @@
+/**
+ * Pin user-cancellation exit code: every cancellation path in the
+ * interactive prompts must call process.exit(4), not exit(0).
+ *
+ * Pre-v1.3 behavior was process.exit(0) (silent success), preventing CI
+ * scripts from distinguishing "completed install" from "user cancelled".
+ * Owner decision in issue #4: introduce code 4 = user cancelled.
+ *
+ * This test is static — it reads prompts.js and asserts the source
+ * contains no exit(0) call inside an isCancel block. Spawn-based SIGINT
+ * tests proved flaky across TTY/non-TTY runners.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = dirname(__filename);
+const PROMPTS_PATH = join(__dirname, '..', 'src', 'installer', 'prompts.js');
+
+test('every cancellation site in prompts.js exits with code 4', () => {
+  const src = readFileSync(PROMPTS_PATH, 'utf8');
+
+  // Find every line that emits process.exit(...) and tag whether it's
+  // inside or after an isCancel(...) check. The grouping window is loose
+  // — anything within 5 lines of an isCancel reference counts.
+  const lines = src.split('\n');
+  let lastIsCancelLine = -10;
+  const exitsToCheck = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    if (/\bisCancel\s*\(/.test(lines[i])) lastIsCancelLine = i;
+    const m = lines[i].match(/process\.exit\((\d+)\)/);
+    if (m && i - lastIsCancelLine <= 5) {
+      exitsToCheck.push({ line: i + 1, code: Number(m[1]), src: lines[i].trim() });
+    }
+  }
+
+  assert.ok(exitsToCheck.length >= 7, `expected at least 7 cancellation sites; found ${exitsToCheck.length}`);
+
+  const wrong = exitsToCheck.filter(e => e.code !== 4);
+  assert.deepEqual(
+    wrong, [],
+    `cancellation sites must use process.exit(4), found:\n${wrong.map(e => `  ${PROMPTS_PATH}:${e.line}: ${e.src}`).join('\n')}`,
+  );
+});
+
+test('docstring on promptForInstall references exit(4)', () => {
+  const src = readFileSync(PROMPTS_PATH, 'utf8');
+  assert.match(
+    src,
+    /Calls process\.exit\(4\)/,
+    'top-level docstring must document the exit(4) cancellation contract',
+  );
+});

--- a/bin/lumina.cancel.test.js
+++ b/bin/lumina.cancel.test.js
@@ -27,6 +27,12 @@ test('every cancellation site in prompts.js exits with code 4', () => {
   // Find every line that emits process.exit(...) and tag whether it's
   // inside or after an isCancel(...) check. The grouping window is loose
   // — anything within 5 lines of an isCancel reference counts.
+  //
+  // Window limitation: if a future site puts more than 5 lines (or a blank
+  // line that pushes the gap past 5) between `isCancel(x)` and its
+  // `process.exit(...)`, this test will silently miss it. Keep the
+  // single-line `if (isCancel(x)) { cancel(...); process.exit(4); }` shape,
+  // or revise this matcher when adding multi-line cases.
   const lines = src.split('\n');
   let lastIsCancelLine = -10;
   const exitsToCheck = [];
@@ -39,7 +45,7 @@ test('every cancellation site in prompts.js exits with code 4', () => {
     }
   }
 
-  assert.ok(exitsToCheck.length >= 7, `expected at least 7 cancellation sites; found ${exitsToCheck.length}`);
+  assert.ok(exitsToCheck.length >= 8, `expected at least 8 cancellation sites; found ${exitsToCheck.length}`);
 
   const wrong = exitsToCheck.filter(e => e.code !== 4);
   assert.deepEqual(

--- a/bin/lumina.js
+++ b/bin/lumina.js
@@ -19,7 +19,8 @@
  *   --packs <list>      — comma-separated pack list for non-interactive install
  *   --ide-targets <list> — comma-separated IDE target list for non-interactive install
  *
- * Exit codes: 0 success, 1 user error, 2 filesystem error, 3 upgrade incompatibility
+ * Exit codes: 0 success, 1 user error, 2 filesystem/safety, 3 internal/network,
+ *             4 user cancelled (Ctrl-C in interactive prompt or declined confirm)
  */
 
 import { createRequire } from 'node:module';
@@ -84,8 +85,9 @@ program
 Exit codes:
   0  success
   1  user error (bad flag, missing prereq)
-  2  filesystem error (permission denied, path outside cwd)
-  3  upgrade incompatibility (manifest references unknown pack)
+  2  filesystem / safety (permission denied, path outside cwd, unknown pack slug)
+  3  internal / network (atomicWrite failure, 5xx, upgrade incompatibility)
+  4  user cancelled (Ctrl-C in interactive prompt or declined confirm)
 
 Flags applicable to all commands:
   --directory <path>  installation directory (defaults to current directory)

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "devDependencies": {},
   "scripts": {
     "test": "npm run test:installer",
-    "test:installer": "node --test src/installer/commands.test.js src/installer/fs.test.js src/installer/locales.test.js src/installer/manifest.test.js src/installer/prompts.test.js src/installer/readme-templates.test.js src/installer/template-engine.test.js src/installer/update-check.test.js",
+    "test:installer": "node --test bin/lumina.cancel.test.js src/installer/commands.test.js src/installer/fs.test.js src/installer/locales.test.js src/installer/manifest.test.js src/installer/prompts.test.js src/installer/readme-templates.test.js src/installer/template-engine.test.js src/installer/update-check.test.js",
     "test:scripts": "node --test src/scripts/lint.test.mjs src/scripts/reset.test.mjs src/scripts/wiki.test.mjs src/scripts/discover-runner.test.mjs src/scripts/external-ids.test.mjs src/scripts/parse-ids.test.mjs src/scripts/merge-ids.test.mjs src/scripts/build-source.test.mjs src/scripts/wiki-yaml-object.test.mjs",
     "test:python": "python3 -m pytest src/tools/tests -q",
     "test:all": "npm run test:installer && npm run test:scripts && npm run test:python",

--- a/src/installer/prompts.js
+++ b/src/installer/prompts.js
@@ -143,7 +143,7 @@ export function buildPromptList(existingManifest, defaultLocale = 'en') {
 /**
  * Run the five interactive install prompts.
  * Returns default answers immediately when `acceptDefaults` is true (--yes mode).
- * Calls process.exit(0) if the user cancels (Ctrl-C).
+ * Calls process.exit(4) if the user cancels (Ctrl-C) or declines a confirm prompt.
  *
  * @param {object}  [opts]
  * @param {boolean} [opts.acceptDefaults=false] - Skip prompts; return defaults.
@@ -174,7 +174,7 @@ export async function runInstallPrompts({ acceptDefaults = false, cwd = process.
   if (isCancel(localeRaw)) {
     // t may be EN or may not be loaded yet — use cancel string from t if available
     cancel(t ? t('prompt.cancelled') : 'Installation cancelled.');
-    process.exit(0);
+    process.exit(4);
   }
   const locale = localeRaw;
   const langDefault = LOCALE_LANGUAGE_NAME[locale] ?? 'English';
@@ -192,7 +192,7 @@ export async function runInstallPrompts({ acceptDefaults = false, cwd = process.
     });
     if (isCancel(proceed) || !proceed) {
       cancel(t ? t('prompt.cancelled') : 'Installation cancelled.');
-      process.exit(0);
+      process.exit(4);
     }
   }
 
@@ -203,7 +203,7 @@ export async function runInstallPrompts({ acceptDefaults = false, cwd = process.
     placeholder: cwdAbs,
     defaultValue: cwdAbs,
   });
-  if (isCancel(directoryRaw)) { cancel(t ? t('prompt.cancelled') : 'Installation cancelled.'); process.exit(0); }
+  if (isCancel(directoryRaw)) { cancel(t ? t('prompt.cancelled') : 'Installation cancelled.'); process.exit(4); }
   const directory = expandUserPath(directoryRaw, cwdAbs);
   const projectName = defaultProjectName(directory);
 
@@ -212,7 +212,7 @@ export async function runInstallPrompts({ acceptDefaults = false, cwd = process.
     message: t ? t('prompt.purpose.message') : 'Research purpose (optional — describe what this wiki is for)',
     placeholder: t ? t('prompt.purpose.placeholder') : 'e.g. Track flash-attention variants for a survey',
   });
-  if (isCancel(researchPurposeRaw)) { cancel(t ? t('prompt.cancelled') : 'Installation cancelled.'); process.exit(0); }
+  if (isCancel(researchPurposeRaw)) { cancel(t ? t('prompt.cancelled') : 'Installation cancelled.'); process.exit(4); }
   const researchPurpose = researchPurposeRaw || '';
 
   // ── Prompt 3: IDE targets ────────────────────────────────────────────────
@@ -230,7 +230,7 @@ export async function runInstallPrompts({ acceptDefaults = false, cwd = process.
     initialValues: ['claude_code'],
     required: false,
   });
-  if (isCancel(ideTargetsRaw)) { cancel(t ? t('prompt.cancelled') : 'Installation cancelled.'); process.exit(0); }
+  if (isCancel(ideTargetsRaw)) { cancel(t ? t('prompt.cancelled') : 'Installation cancelled.'); process.exit(4); }
   const ideTargets = Array.isArray(ideTargetsRaw) && ideTargetsRaw.length > 0
     ? ideTargetsRaw
     : ['claude_code'];
@@ -244,7 +244,7 @@ export async function runInstallPrompts({ acceptDefaults = false, cwd = process.
     ],
     required: false,
   });
-  if (isCancel(packsRaw)) { cancel(t ? t('prompt.cancelled') : 'Installation cancelled.'); process.exit(0); }
+  if (isCancel(packsRaw)) { cancel(t ? t('prompt.cancelled') : 'Installation cancelled.'); process.exit(4); }
   const selectedPacks = Array.isArray(packsRaw) ? packsRaw : [];
   const packs = ['core', ...selectedPacks.filter(p => p !== 'core')];
 
@@ -254,7 +254,7 @@ export async function runInstallPrompts({ acceptDefaults = false, cwd = process.
     placeholder: langDefault,
     defaultValue: langDefault,
   });
-  if (isCancel(communicationLangRaw)) { cancel(t ? t('prompt.cancelled') : 'Installation cancelled.'); process.exit(0); }
+  if (isCancel(communicationLangRaw)) { cancel(t ? t('prompt.cancelled') : 'Installation cancelled.'); process.exit(4); }
   const communicationLang = communicationLangRaw || langDefault;
 
   const documentOutputLangRaw = await text({
@@ -262,7 +262,7 @@ export async function runInstallPrompts({ acceptDefaults = false, cwd = process.
     placeholder: langDefault,
     defaultValue: langDefault,
   });
-  if (isCancel(documentOutputLangRaw)) { cancel(t ? t('prompt.cancelled') : 'Installation cancelled.'); process.exit(0); }
+  if (isCancel(documentOutputLangRaw)) { cancel(t ? t('prompt.cancelled') : 'Installation cancelled.'); process.exit(4); }
   const documentOutputLang = documentOutputLangRaw || langDefault;
 
   return {


### PR DESCRIPTION
## Summary

Final PR of the **Stability Lock** roadmap item. Implements owner decision Q2 from issue #4: introduce new exit code **4 = user cancelled** rather than the breaking-change alternative of switching to SIGINT convention 130.

## Behavior change

| Scenario | Pre-v1.3 | v1.3+ |
|---|---|---|
| `lumina install` → user presses Ctrl-C | exit **0** (silent success) | exit **4** |
| `lumina install` → user declines locale-switch confirm | exit **0** | exit **4** |
| `lumina install --yes` → completes successfully | exit 0 | exit 0 (unchanged) |
| `lumina install` → bad flag | exit 1 | exit 1 (unchanged) |
| `lumina install` → fs error | exit 2 or 3 | exit 2 or 3 (unchanged) |

CI scripts that previously checked `exit === 0` for success will now correctly treat cancellation as failure (the buggy old behavior was silent success). Scripts checking `exit !== 0` for failure already caught these cases — those continue to work, with cancellation now distinguishable from internal errors.

## Implementation

- `src/installer/prompts.js`: 7 `process.exit(0)` → `process.exit(4)` at every `isCancel`-guarded site:
  - Locale prompt (Ctrl-C)
  - Locale-switch confirm (decline or Ctrl-C)
  - Install directory text prompt
  - Research purpose select
  - IDE targets multiselect
  - Packs multiselect
  - Communication language select
  - Document output language select
- `bin/lumina.js`: module docstring + `--help` exit-code section both document code 4.

## Test (`bin/lumina.cancel.test.js`)

Static source-level check rather than spawn-based SIGINT:
- Every `process.exit(N)` call within 5 lines of an `isCancel(...)` reference must have `N === 4` (catches accidental regression)
- The module docstring on `promptForInstall` references `process.exit(4)` (catches doc drift)

### Why static instead of integration?

I tried a spawn-based SIGINT test first. It worked locally on a TTY but produced `null` exit codes (signal-terminated) when stdin was piped — exactly the case CI runners hit. `@clack/prompts` SIGINT handling depends on raw-mode TTY availability. The static check covers every realistic regression (developer editing one of the 7 sites without thinking about the contract) without environment fragility. Documented in the test file.

## Verification

- `npm run test:installer` — new + all existing pass
- `npm run ci:idempotency` — clean (multilingual EN/VI/ZH stable)

## Stability Lock — final status

| PR | Title | Status |
|---|---|---|
| #10 (PR-1) | `fix(cli): align exit codes + pin contract` | Pending |
| #11 (PR-2) | `docs(cli): publish v1.x CLI contract` | Pending |
| #12 (PR-3) | `feat(cli): deprecate --cwd with stderr warning` | Pending |
| **#13 (this, PR-4)** | `feat(cli): introduce exit code 4 for user cancellation` | — |

After all four merge, issue #4 can close. Suggested merge order: #10 → #11 → #12 → #13. The order matters only for cleanest history; each PR is independently correct.

## Test plan

- [x] Static source check: 7 cancellation sites all use exit 4
- [x] Docstring updated and verified by test
- [x] `--help` output shows code 4
- [x] Idempotency CI clean
- [ ] Owner verifies the non-breaking framing is acceptable (vs preferring SIGINT 130)