### PR TITLE
docs: sync project docs with v1.x stability lock

### DIFF
--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -1,0 +1,216 @@
+# Lumina-Wiki — Code Standards & Checklist
+
+**Status:** Locked for v0.1+  
+**Applies to:** All code in `src/`, `scripts/`, `bin/`
+
+---
+
+## Core Non-Negotiables
+
+These are absolutes. Violations map to real failure modes. For the full rationale, see [docs/project-context.md](./project-context.md) §3.
+
+### File & Filesystem (4 rules)
+
+| Rule | Applies To | Violation Impact |
+|------|-----------|------------------|
+| **Atomic writes always** — use `atomicWrite()` (temp + fsync + rename); never `fs.writeFile` | All file writes (JS/Python) | Silent data loss on crash |
+| **`safePath()` for all user input** — rejects `..`, absolute paths, Windows drive letters | All path fragments from users/configs | Directory traversal vulnerability |
+| **Path joins via `node:path` or `pathlib`** — never string-concatenate | All path construction | Cross-platform breakage on Windows |
+| **Never use native modules** — no `node-gyp`, `bcrypt`, or compiled binaries | Dependencies, bin/* | Breaks on sandboxed installs; CI failure |
+
+### Release & Deployment (2 rules)
+
+| Rule | Applies To | Violation Impact |
+|------|-----------|------------------|
+| **No `postinstall` script** in `package.json` | Root `package.json` | npm publish blocks; CI gate fails |
+| **`devDependencies: {}` is intentional** — never add Jest, Vitest, or test frameworks | Dependencies | Cold-start bloat; breaks publishing |
+
+### Performance (1 rule)
+
+| Rule | Applies To | Violation Impact |
+|------|-----------|------------------|
+| **Cold-start < 300 ms** — lazy-import heavy deps inside `.action()` callbacks | `bin/lumina.js`, subcommand modules | CLI feels sluggish; UX regresses |
+
+### Wiki Invariants (4 rules)
+
+| Rule | Applies To | Violation Impact |
+|------|-----------|------------------|
+| **Bidirectional links mandatory** — every forward link writes its reverse in one operation | `wiki.mjs`, skill prompts | Graph becomes inconsistent; linter fails |
+| **`graph/` is auto-generated** — never hand-edit `edges.jsonl` or `citations.jsonl` | `src/scripts/`, skills | Graph corruption on next rebuild |
+| **`raw/` is read-only** — only `raw/tmp/` and `raw/discovered/` accept new files (append, no overwrites) | Skills, tools | User data loss risk |
+| **Exit codes are contractual** — always use: `0` success, `1` user error, `2` fs/path-safety, `3` internal, `4` user cancellation | `bin/lumina.js`, tools | Tools depending on exit codes fail silently |
+
+---
+
+## Naming Conventions
+
+### Files & Directories
+
+- **Kebab-case** for filenames: `extract-pdf.py`, `template-engine.js`, `schema-validator.mjs`
+- **Descriptive names** — filename itself should hint at purpose when listed by `ls` or grep
+- **Module types:**
+  - `.js` — Node CommonJS (legacy; rare in this codebase)
+  - `.mjs` — Node ESM (standard for src/scripts/)
+  - `.py` — Python 3.9+ (tools only)
+  - `.md` — Markdown (docs, skills, templates)
+
+### Code Identifiers
+
+- **camelCase** for variables, functions, parameters (JS/Python)
+- **PascalCase** for classes, types, exported named exports
+- **UPPER_SNAKE_CASE** for constants (both JS and Python)
+- **Abbreviations:** Avoid unless universally known (e.g., `fs`, `API` OK; `cfg`, `proc` not OK)
+
+---
+
+## When Editing Module X, Also Update Y
+
+**Schema changes propagate:**
+
+| You edit | You must also update | Why |
+|----------|----------------------|-----|
+| `src/scripts/schemas.mjs` | `src/scripts/wiki.mjs` + `src/scripts/lint.mjs` | SSOT definition; other modules consume |
+| `src/scripts/wiki.mjs` (graph mutations) | Tests in `src/scripts/wiki.test.mjs`; verify `/lumi-ingest` skill still works | Public API change risk |
+| `src/installer/commands.js` (install flow) | `ci-idempotency.mjs` test if watched paths change | Idempotency contract must hold |
+| Any skill prompt | User-facing README.md references (if skill description changes) | Docs drift risk |
+| `bin/lumina.js` (CLI surface) | Test in `src/installer/commands.test.js` + CLAUDE.md (if exit codes change) | Agent scripts depend on behavior |
+| Python tool args/output | Corresponding skill prompt (`src/skills/**/SKILL.md`) | Skills invoke tools; JSON contract must align |
+
+---
+
+## File Size Guideline
+
+**Target:** ≤ 200 LOC per file (soft cap)
+
+**When to split:**
+- Source file exceeds 200 LOC → extract helper functions to `lib/` subdir
+- Test file exceeds 150 LOC → split by test category or module under test
+- Skill prompt exceeds 80 LOC → move step details to reference files (`step-01-*.md`) + thin router in `SKILL.md`
+
+**Exceptions (OK to exceed):**
+- `src/installer/commands.js` (1090 LOC) — 18-step install flow; justified by complexity; every step numbered for grep
+- Config files, Markdown docs, test fixtures (no split needed)
+
+---
+
+## API Contracts
+
+### `wiki.mjs` (Only Mutation Path)
+
+Skills invoke via Bash + JSON, never import. Contract:
+
+```bash
+# Read
+node _lumina/scripts/wiki.mjs read --entity-type source --slug my-paper
+# Output: JSON to stdout
+
+# Mutate (all changes atomic)
+node _lumina/scripts/wiki.mjs create --entity-type source --slug my-paper --frontmatter '{...}'
+# Output: JSON to stdout; errors to stderr with code 2 or 3
+
+# Exit codes
+# 0 — success
+# 1 — validation error (bad input from caller)
+# 2 — filesystem / path safety / unknown slug
+# 3 — internal error (log corruption, race, etc.)
+```
+
+### Skill JSON Protocol
+
+Skills receive JSON from tools, always validate schema:
+
+```bash
+node _lumina/tools/extract_pdf.py "raw/my.pdf" > /tmp/out.json
+# Output: {"pages": [{"text": "...", "images": [...]}], "metadata": {...}}
+# On error: exit 2 with stderr message
+```
+
+Skill re-formats for agent (`/lumi-ingest` constructs page frontmatter from JSON).
+
+---
+
+## Testing Standards
+
+**No external test framework.** Use built-in tools:
+- **JS/MJS:** `node --test` + `node:assert/strict`
+- **Python:** `pytest -q` + standard `unittest` assertions
+
+**Coverage targets:**
+- Installer: All path safety, manifest versioning, template rendering
+- Scripts: Schema invariants, idempotency, graph consistency
+- Tools: Fetcher contract validation, error handling
+
+**Run before push:**
+```bash
+npm run test:all && npm run ci:idempotency && npm run ci:package
+```
+
+---
+
+## Output & Formatting
+
+### Color & TTY
+
+- **Always check** `process.stdout.isTTY && !process.env.NO_COLOR` before emitting ANSI codes
+- **Use helper** `getColorFns()` (don't call `picocolors` directly)
+- **CLI output:** UTF-8, LF line endings (cross-platform)
+
+### Error Messages
+
+- **User error (exit 1):** Name the offending input, suggest fix if obvious
+- **FS/path error (exit 2):** Print full path, explain safety violation
+- **Internal error (exit 3):** Include stack trace in debug mode only; log to stderr
+
+### Markdown (Skills, Docs)
+
+- **Headings:** `#` H1 (title), `##` H2 (sections), `###` H3 (subsections)
+- **Lists:** Bullet for unordered, numbered for steps
+- **Code blocks:** Specify language (`bash`, `js`, `python`, `json`)
+- **Links:** Relative paths within `docs/`, absolute for external URLs
+
+---
+
+## Security & Privacy
+
+| Concern | Standard | Check |
+|---------|----------|-------|
+| **Path traversal** | `safePath()` rejects `..` and absolutes | Every file I/O path |
+| **Secrets in git** | No `.env` (template only), no keys in code | Pre-commit check: `git diff --cached | grep -i "password\|api_key"` |
+| **Telemetry** | Zero; only optional npm registry check (2s timeout, suppressible) | Audit all outbound network calls |
+| **Data isolation** | User workspace never leaves filesystem unless explicitly fetched (tools) | Skills read only `wiki/`, `raw/`, `_lumina/` |
+
+---
+
+## Changelog & Versioning
+
+- **SemVer:** `major.minor.patch` (major only on breaking schema changes)
+- **Changelog format:** [Keep a Changelog](https://keepachangelog.com)
+- **Commit messages:** Conventional commits (feat:, fix:, docs:, refactor:, test:, chore:)
+
+---
+
+## Pre-Push Checklist
+
+Before `git push`:
+
+- [ ] No `devDependencies` added
+- [ ] No `postinstall` script in `package.json`
+- [ ] All tests pass: `npm run test:all` (includes Python tests)
+- [ ] Idempotency holds: `npm run ci:idempotency`
+- [ ] Package validates: `npm run ci:package`
+- [ ] Cold-start measured (< 300 ms)
+- [ ] All file writes use `atomicWrite()` or `os.replace()`
+- [ ] All user paths validated with `safePath()`
+- [ ] Exit codes correct (0, 1, 2, 3, 4 only)
+- [ ] No emoji in shipped files
+- [ ] Docs updated if API/behavior changed
+
+---
+
+## See Also
+
+- **Full critical rules:** [docs/project-context.md](./project-context.md) — read before editing code
+- **Codebase map:** [docs/codebase-summary.md](./codebase-summary.md)
+- **System architecture:** [docs/system-architecture.md](./system-architecture.md)
+- **Development workflows:** [docs/DEVELOPMENT.md](./DEVELOPMENT.md)
+- **Locked design decisions:** [docs/planning-artifacts/architecture.md](./planning-artifacts/architecture.md)

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -1,0 +1,185 @@
+# Lumina-Wiki — Codebase Summary
+
+**Project:** Multi-IDE, npm-published wiki scaffolder  
+**Runtime:** Node ESM ≥20, Python 3.9+ (optional)  
+**Current Version:** 1.1.0 (2026-05-06)  
+**Total LOC:** ~12,273 (src/installer + src/scripts)
+
+---
+
+## Repository Structure
+
+```
+lumina-wiki/
+├── bin/
+│   └── lumina.js                 # CLI entry point (ESM, lazy-imports subcommands)
+├── src/
+│   ├── installer/                # Installer modules (Node, ESM)
+│   │   ├── commands.js           # 18-step install/upgrade flow [1090 LOC]
+│   │   ├── fs.js                 # Atomic writes, symlink ladder, safePath()
+│   │   ├── manifest.js           # Manifest read/write (JSON with CSV state)
+│   │   ├── template-engine.js    # {{var}} + {{#if}} rendering
+│   │   ├── prompts.js            # @clack/prompts UX (lazy-loaded)
+│   │   ├── update-check.js       # npm registry version check (2s timeout)
+│   │   ├── banner.js             # TTY-aware colorized output
+│   │   └── *.test.js             # Unit + integration tests (node --test)
+│   ├── scripts/                  # Wiki engine & tools (Node, ESM)
+│   │   ├── wiki.mjs              # Graph mutation, frontmatter validation
+│   │   ├── lint.mjs              # Schema linter (9 checks: L01–L09)
+│   │   ├── reset.mjs             # Scoped destructive reset (--scope all)
+│   │   ├── schemas.mjs           # Single source of truth (entities, edges, frontmatter)
+│   │   ├── discover-runner.mjs   # Scheduled discovery scheduler
+│   │   ├── lib/*.mjs             # Helper modules
+│   │   └── *.test.mjs            # Tests (node --test)
+│   ├── tools/                    # Python tools (optional, research pack)
+│   │   ├── extract_pdf.py        # PDF text extraction [core]
+│   │   ├── discover.py           # Research discovery orchestrator
+│   │   ├── fetch_arxiv.py        # arXiv API fetcher
+│   │   ├── fetch_s2.py           # Semantic Scholar fetcher
+│   │   ├── fetch_wikipedia.py    # Wikipedia fetcher
+│   │   ├── fetch_deepxiv.py      # DeepXiv (preprint aggregator) fetcher
+│   │   ├── fetch_pdf.py          # Generic PDF downloader
+│   │   ├── prepare_source.py     # Content prep (.pdf, .tex, .html, .md, .txt)
+│   │   ├── init_discovery.py     # Watchlist initialization
+│   │   ├── _env.py               # Environment & API key loader
+│   │   └── tests/                # pytest suite
+│   ├── skills/                   # Agent prompts (Markdown)
+│   │   ├── core/                 # 6 core skills (always installed)
+│   │   │   ├── init/SKILL.md
+│   │   │   ├── ingest/SKILL.md
+│   │   │   ├── ask/SKILL.md
+│   │   │   ├── edit/SKILL.md
+│   │   │   ├── check/SKILL.md
+│   │   │   └── reset/SKILL.md
+│   │   ├── research/             # 4 research skills (opt-in)
+│   │   │   ├── discover/SKILL.md
+│   │   │   ├── survey/SKILL.md
+│   │   │   ├── prefill/SKILL.md
+│   │   │   └── research-topic/SKILL.md
+│   │   └── reading/              # 4 reading skills (opt-in)
+│   │       ├── chapter-ingest/SKILL.md
+│   │       ├── character-track/SKILL.md
+│   │       ├── theme-map/SKILL.md
+│   │       └── plot-recap/SKILL.md
+│   └── templates/                # Workspace payload (rendered at install)
+│       ├── _lumina/              # Framework config & state (never edit directly)
+│       ├── wiki/                 # Empty seed directory
+│       ├── raw/                  # User-provided input
+│       ├── README.md             # Canonical agent-context file
+│       ├── CLAUDE.md, AGENTS.md, GEMINI.md # IDE stubs
+│       └── .env.example          # Optional API key template
+├── scripts/                      # CI/dev helpers
+│   ├── dev-sandbox.mjs           # Temp-dir install harness
+│   ├── ci-idempotency.mjs        # Reinstall + git-diff gate
+│   └── ci-package.mjs            # Validate npm pack output
+├── docs/                         # Developer documentation
+│   ├── project-context.md        # Critical rules for AI agents
+│   ├── DEVELOPMENT.md            # Local dev/test workflows
+│   ├── deployment.md             # Cloudflare Pages deployment
+│   ├── planning-artifacts/       # Architecture decisions, specs
+│   ├── implementation-artifacts/ # Deferred work, implementation notes
+│   └── user-guide/               # End-user guides (EN, VI, ZH)
+├── .github/workflows/            # CI matrix (Node 20/22 × 3 platforms)
+├── package.json                  # ESM, no devDependencies, 5 deps
+├── package-lock.json
+├── CLAUDE.md                     # Agent rules (read first)
+├── README.md                     # User-facing intro + schema
+├── README.vi.md, README.zh.md    # Localized READMEs
+├── CHANGELOG.md
+├── ROADMAP.md
+└── LICENSE
+```
+
+---
+
+## Key Modules by Size & Purpose
+
+| Module | LOC | Purpose |
+|--------|-----|---------|
+| `src/installer/commands.js` | 1090 | Core 18-step install/upgrade flow |
+| `src/scripts/wiki.mjs` | 800+ | Graph mutation, page creation, frontmatter handling |
+| `src/scripts/lint.mjs` | 400+ | Schema validation (9 checks) |
+| `src/installer/fs.js` | 300+ | Atomic writes, symlink ladder, safePath() |
+| `src/scripts/schemas.mjs` | 250+ | Single source of truth (entities, edges, exemptions) |
+| `src/installer/manifest.js` | 250+ | Manifest versioning & state file I/O |
+| `src/installer/template-engine.js` | 200+ | Handlebars-style template rendering |
+| `src/tools/extract_pdf.py` | 150+ | PDF text extraction (pypdf-based) |
+| `src/tools/discover.py` | 200+ | Discovery orchestrator (research pack) |
+
+---
+
+## Single Source of Truth
+
+**`src/scripts/schemas.mjs`** defines the entire wiki contract:
+
+- **Entity types:** `source`, `concept`, `person`, `summary`, `topic` (+ pack-specific).
+- **Edge types:** 28 directed relationships (e.g., `cites`, `defines`, `relates_to`).
+- **Frontmatter requirements:** Mandatory fields per entity type.
+- **Exemption globs:** Paths that don't require bidirectional reverse links (foundations/\*\*, outputs/\*\*, external URLs).
+
+Changes to `schemas.mjs` propagate to:
+- `wiki.mjs` — enforces on create/mutate.
+- `lint.mjs` — validates on read.
+- Installer templates — reflected in entry-point context (README.md).
+
+---
+
+## Write Paths (Atomic Discipline)
+
+| Path | Tool | Operation |
+|------|------|-----------|
+| `wiki/`, `graph/`, `log.md` | `wiki.mjs` | Only allowed mutation path; always atomic. Skills invoke via Bash + JSON. |
+| `wiki/`, `graph/`, `log.md` (repair) | `lint.mjs --fix` | Lints (9 checks), repairs L01–L07 issues atomically. |
+| `wiki/`, `_lumina/` (destructive) | `reset.mjs` | Scoped deletion; respects `--scope` flag. |
+| All installer outputs | `fs.js:atomicWrite()` | Temp + fsync + rename; manifest written last. |
+| All Python writes | `os.replace()` | Temp file + fsync + atomic rename. |
+
+---
+
+## Test Coverage
+
+| Suite | Command | Coverage |
+|-------|---------|----------|
+| **Installer** | `npm run test:installer` | `fs.js`, `manifest.js`, `template-engine.js`, `update-check.js`, `commands.js` (node --test) |
+| **Scripts** | `npm run test:scripts` | `wiki.mjs`, `lint.mjs`, `reset.mjs`, `discover-runner.mjs` (node --test) |
+| **Python** | `npm run test:python` | Fetcher contracts, env loading, prepare_source (pytest) |
+| **Idempotency** | `npm run ci:idempotency` | Install twice → git diff over watched paths must be empty |
+| **Packaging** | `npm run ci:package` | npm pack validation; no postinstall script; files allowlist |
+
+---
+
+## Dependencies
+
+**Direct (5 total):**
+- `commander@^12.1.0` — CLI parsing
+- `@clack/prompts@^0.9.1` — Interactive install prompts (lazy-loaded)
+- `js-yaml@^4.1.0` — Config read on upgrade
+- `picocolors@^1.1.1` — TTY-aware color (lazy-loaded)
+- `glob@^11.0.0` — Template expansion
+
+**Python (research pack, optional):**
+- `requests>=2.31` — HTTP fetching
+- `pypdf>=4.0` — PDF extraction (core dependency, always available)
+- `pytest>=7` — Testing
+
+**Zero Native Modules:** No `bcrypt`, `node-gyp`, or C++ binding complexity.
+
+---
+
+## Cold-Start Budget
+
+**Target:** < 300 ms  
+**Mechanism:** All subcommands, heavy deps lazy-imported inside `.action()` callbacks.
+- `bin/lumina.js` itself: ~50 ms (Commander + minimal setup).
+- `install` subcommand (first import): ~200 ms (loads prompts, yaml, colorize, template-engine).
+
+---
+
+## See Also
+
+- **Project vision & scope:** [docs/project-overview-pdr.md](./project-overview-pdr.md)
+- **Code standards & non-negotiables:** [docs/code-standards.md](./code-standards.md)
+- **System architecture & flow:** [docs/system-architecture.md](./system-architecture.md)
+- **Locked v0.1 decisions:** [docs/planning-artifacts/architecture.md](./planning-artifacts/architecture.md)
+- **Development workflows:** [docs/DEVELOPMENT.md](./DEVELOPMENT.md)
+- **Critical agent rules:** [docs/project-context.md](./project-context.md)

--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -70,6 +70,7 @@ These are absolutes. Every one corresponds to a real failure mode.
    - `1` — user error (bad args)
    - `2` — filesystem / path safety / unknown slug / missing `--yes`
    - `3` — internal / fs failure / upgrade incompatibility / 5xx network
+   - `4` — user cancellation (Ctrl-C in interactive prompt or declined confirm)
 
 ### Cold-start
 

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -1,0 +1,134 @@
+# Lumina-Wiki — Project Overview & PDR
+
+**Version:** 1.1.0 (2026-05-06)  
+**Status:** Stable  
+**Repository:** [github.com/tronghieu/lumina-wiki](https://github.com/tronghieu/lumina-wiki)  
+**Package:** [lumina-wiki on npm](https://www.npmjs.com/package/lumina-wiki)
+
+---
+
+## Vision
+
+Turn every AI agent into a personal knowledge assistant by scaffolding an LLM-maintainable research wiki in seconds. Realize Karpathy's LLM-Wiki vision — the LLM reads a structured, cross-referenced knowledge graph instead of re-deriving insights from raw chunks on every query.
+
+---
+
+## Problem & Solution
+
+**Problem:** Researchers and engineers waste time re-reading the same papers, re-deriving the same concepts, and losing context between sessions because knowledge lives scattered across PDFs, notes, and browser tabs.
+
+**Solution:** Lumina-Wiki installs a one-command knowledge workspace (`npx lumina-wiki install`) that agents maintain over time. You provide raw materials (`raw/` folder); agents build a structured wiki (`wiki/`) with frontmatter, bidirectional links, and a queryable graph. Every query uses the agent's compiled knowledge, not raw chunks.
+
+---
+
+## Target Users
+
+- **Researchers** running multiple literature reviews across papers, topics, and ideas
+- **Engineers** building knowledge bases for code, architecture, and system design
+- **Students** synthesizing course materials, notes, and external resources
+- **LLM-power-users** (Claude Code, Codex, Cursor, Gemini CLI) who want a persistent "second brain"
+
+---
+
+## Core Workflow
+
+```
+raw/                       →  /lumi-ingest   →   wiki/
+(your inputs)              (agent processes)      (structured KB)
+- PDF, .txt, notes         ┌──────────────┐      - concept.md
+- research downloads       │ Extract text │      - source.md
+                           │ Build links  │      - frontmatter
+                           │ Cross-ref    │      - graph/
+                           └──────────────┘
+     ↓↓↓                                     ↑↑↑
+  You manage              /lumi-ask, /lumi-ask
+  (append, never edit)    (query against graph)
+```
+
+Three-step loop:
+1. Place documents in `raw/`.
+2. Run `/lumi-ingest` to parse and cross-reference.
+3. Query with `/lumi-ask` against the compiled wiki.
+
+---
+
+## Scope: v0.1 / v1.x
+
+### Installed Components
+
+- **Installer** (`bin/lumina.js`): Cross-platform, atomic file writes, symlink fallback ladder (Windows compat).
+- **Wiki Engine** (`src/scripts/wiki.mjs`): Graph mutation, frontmatter validation, bidirectional link enforcement.
+- **Linter** (`src/scripts/lint.mjs`): 9 checks for schema compliance, slug format, missing reverse links, index freshness.
+- **Skills** (14 total; v1.1.0):
+  - **Core** (6, always installed): `/lumi-init`, `/lumi-ingest`, `/lumi-ask`, `/lumi-edit`, `/lumi-check`, `/lumi-reset`
+  - **Research pack** (4, opt-in): `/lumi-discover`, `/lumi-survey`, `/lumi-prefill`, `/lumi-research-topic`
+  - **Reading pack** (4, opt-in): `/lumi-chapter-ingest`, `/lumi-character-track`, `/lumi-theme-map`, `/lumi-plot-recap`
+- **Python Tools**:
+  - **Core:** `extract_pdf.py` (text extraction from PDFs; shipped with all installs).
+  - **Research pack:** `prepare_source.py` (local source preparation — .pdf, .tex, .html, .md, .txt), `fetch_arxiv.py`, `fetch_s2.py`, `fetch_wikipedia.py`, `fetch_deepxiv.py`.
+
+### Architecture
+
+Two layers:
+- **Installer layer** — Node ESM (≥20), no native modules, sub-300ms cold-start, idempotent (install twice → git diff is empty).
+- **Workspace payload** — Node scripts + Python tools + Markdown skill prompts (no runtime dependencies on installer).
+
+### Core Invariants
+
+| Invariant | Enforced By |
+|-----------|-------------|
+| `raw/` is read-only | Installer + schema policy |
+| `graph/` is auto-generated | `wiki.mjs rebuild` only |
+| Bidirectional links mandatory | `wiki.mjs` + linter L06 |
+| `log.md` append-only | `wiki.mjs` contract |
+| Atomic file writes | `atomicWrite()` helper |
+| Exit codes contractual | `bin/lumina.js` exit guard |
+
+---
+
+## Non-Goals (v0.1)
+
+- MCP `llm-review` bundling (users can wire in second-model review themselves).
+- LaTeX, paper-generation, or rebuttal workflows.
+- Standalone GUI / desktop app (next phase).
+- Telemetry or cloud sync (zero network except optional npm registry check).
+- Custom domain-specific packs (pre-designed templates are future work).
+
+---
+
+## Success Metrics
+
+| Metric | Target | Status |
+|--------|--------|--------|
+| Install time | < 60 s | ✓ |
+| Cold-start CLI | < 300 ms | ✓ |
+| Idempotent reinstall | `git diff` empty | ✓ |
+| Cross-platform (Node 20/22 × macOS/Linux/Windows) | 6-cell CI green | ✓ |
+| Zero-tolerance path safety | No `..` / absolute traversal | ✓ |
+| User adoption | Open-source usage, GitHub stars | Growing |
+| Skill extensibility | 3+ custom-authored packs possible | ✓ (research/reading packs ship; more TBD) |
+
+---
+
+## Release History
+
+- **v1.1.0** (2026-05-06): `/lumi-research-topic` skill, improved READMEs & guides.
+- **v1.0.0** (2026-05-06): Scheduled discovery runner, watchlist configuration.
+- **v0.9.x** (2026-05-05): `/lumi-verify` cross-check, multi-step `/lumi-ingest` workflow.
+- **v0.8.x** (2026-05-03): `raw_paths` field, `fetch_pdf.py`, Mode B URL ingestion.
+- **v0.5.0** (2026-05-02): Initial public release.
+
+See [CHANGELOG.md](../CHANGELOG.md) for full release notes.
+
+---
+
+## See Also
+
+- **User-facing intro:** [README.md](../README.md) (or `README.vi.md`, `README.zh.md`)
+- **Agent rules & architecture:** [CLAUDE.md](../CLAUDE.md)
+- **Critical rules for developers:** [docs/project-context.md](./project-context.md)
+- **Local dev & testing:** [docs/DEVELOPMENT.md](./DEVELOPMENT.md)
+- **Locked v0.1 architecture:** [docs/planning-artifacts/architecture.md](./planning-artifacts/architecture.md)
+- **Full PRD:** [docs/planning-artifacts/prd.md](./planning-artifacts/prd.md)
+- **Feature specs:** [docs/planning-artifacts/specs/](./planning-artifacts/specs/)
+- **Roadmap:** [ROADMAP.md](../ROADMAP.md)

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,0 +1,120 @@
+# Lumina-Wiki — Roadmap Snapshot
+
+**Current Version:** 1.1.0 (2026-05-06)  
+**Canonical source:** [ROADMAP.md](../ROADMAP.md) at project root  
+**Updated:** 2026-05-06
+
+---
+
+## Current Release Highlights
+
+**v1.1.0** adds `/lumi-research-topic` skill (research pack) — cluster existing concepts and sources into a thematic topic page under `wiki/topics/`. AI proposes the cluster from the graph; you confirm before anything is written.
+
+**v1.0.0** brings scheduled discovery runner and watchlist configuration for background research monitoring.
+
+See [CHANGELOG.md](../CHANGELOG.md) for full release history.
+
+---
+
+## Near-term (v1.x Maintenance & Polish)
+
+Focus: Stability, local capabilities, and v1.x feature expansion.
+
+| Feature | Status | Spec |
+|---------|--------|------|
+| **`/lumi-help` RAG-based assistant** | Planned | [spec-lumi-help.md](./planning-artifacts/specs/spec-lumi-help.md) |
+| **Multilingual installer** (EN/VI/ZH prompts) | Planned | [spec-multilingual-installer.md](./planning-artifacts/specs/spec-multilingual-installer.md) |
+| **Local text-document ingestion** (.docx, .rtf, .epub) | Planned | — |
+| **Vision/OCR ingestion** (.png, .jpg, scanned PDF) | Design pending | — |
+| **Paper ranking & influence** (citation counts, altmetrics) | Planned | [spec-paper-ranking.md](./planning-artifacts/specs/spec-paper-ranking.md) |
+| **CI/CD hardening** (Bun, Node 22 LTS) | Planned | — |
+| **Stability lock** (CLI contract published; --cwd deprecation; exit-4 cancellation) | Shipped v1.x | — |
+| **Schema parity** (cross-source ID handling) | In progress | — |
+
+---
+
+## Long-term (Deep Capabilities & Integrity)
+
+Focus: Structural expansion, multi-source synthesis, and rich ingestion.
+
+| Feature | Status | Spec |
+|---------|--------|------|
+| **Research expansion** (OpenAlex, CORE, Unpaywall, RSS) | Proposed | [spec-research-expansion.md](./planning-artifacts/specs/spec-research-expansion.md) |
+| **Google Workspace integration** (Docs, Sheets) | Proposed | [spec-universal-ingestion.md](./planning-artifacts/specs/spec-universal-ingestion.md) |
+| **Multimedia ingestion** (Audio, YouTube, podcasts via transcripts) | Proposed | [spec-universal-ingestion.md](./planning-artifacts/specs/spec-universal-ingestion.md) |
+| **Knowledge graph auditing** (semantic consistency checks, contradiction detection) | Proposed | [spec-kg-audit.md](./planning-artifacts/specs/spec-kg-audit.md) |
+
+---
+
+## Proposed (Future Explorations)
+
+Lower priority; research, community feedback, or alignment with external needs may accelerate:
+
+- **Domain packs** — Specialized biomedical / physics / ML-specific templates and skills
+- **Local cache layer** — Session-level caching for fetcher responses to optimize rate limits
+- **Intelligence layer** — Graph-walking algorithms for "missing link" or "relevant paper" recommendations
+- **Desktop app** — Electron/Tauri standalone UI for richer GUI and native OS integration
+
+---
+
+## Recently Completed (v0.9–v1.1)
+
+| Release | Date | Highlights |
+|---------|------|-----------|
+| **v1.1.0** | 2026-05-06 | `/lumi-research-topic` skill; improved READMEs; CLI contract published; --cwd deprecation; exit-4 cancellation |
+| **v1.0.0** | 2026-05-06 | Scheduled discovery runner; watchlist config; multi-IDE support finalized |
+| **v0.9.x** | 2026-05-05 | `/lumi-verify` cross-check skill; multi-step `/lumi-ingest` workflow with checkpoints |
+| **v0.8.x** | 2026-05-03 | `raw_paths` field; `fetch_pdf.py` tool; Mode B URL ingestion |
+| **v0.5.0** | 2026-05-02 | Initial public release on npm |
+
+---
+
+## Success Criteria (v0.1+)
+
+All locked:
+
+- ✅ **Install time:** < 60 s (baseline)
+- ✅ **Cold-start CLI:** < 300 ms (baseline)
+- ✅ **Idempotent reinstall:** `git diff` empty over watched paths
+- ✅ **Cross-platform:** Node 20/22 × {macOS, Linux, Windows}
+- ✅ **Zero path safety issues:** `safePath()` enforced everywhere
+- ✅ **Skills installed correctly:** Symlink ladder works; fallback to copy on Windows
+- ✅ **Zero telemetry:** Only optional npm registry version check (2s timeout)
+
+---
+
+## Backlog & Deferred Work
+
+See [docs/implementation-artifacts/deferred-work.md](./implementation-artifacts/deferred-work.md) for items explicitly deferred:
+
+- v0.10+ feature specs
+- MCP server for /llm-review (users can wire in themselves)
+- LaTeX/paper-generation pipelines
+- Custom domain packs
+
+---
+
+## How to Track Progress
+
+1. **Detailed specs:** Browse [docs/planning-artifacts/specs/](./planning-artifacts/specs/) for near-term and long-term features
+2. **Implementation notes:** [docs/implementation-artifacts/](./implementation-artifacts/) tracks completed & deferred work
+3. **Release notes:** [CHANGELOG.md](../CHANGELOG.md) documents what shipped in each version
+4. **GitHub issues:** Open tickets reflect community needs and maintenance priorities
+
+---
+
+## For Contributors
+
+- **Starting a feature?** Check [docs/project-context.md](./project-context.md) for critical rules, then [docs/DEVELOPMENT.md](./DEVELOPMENT.md) for dev setup.
+- **Architecture questions?** Read [docs/system-architecture.md](./system-architecture.md) for two-layer design, then [docs/planning-artifacts/architecture.md](./planning-artifacts/architecture.md) for locked decisions.
+- **Code standards?** See [docs/code-standards.md](./code-standards.md) for checklist and non-negotiables.
+
+---
+
+## See Also
+
+- **Canonical roadmap:** [ROADMAP.md](../ROADMAP.md)
+- **Changelog:** [CHANGELOG.md](../CHANGELOG.md)
+- **Full PRD:** [docs/planning-artifacts/prd.md](./planning-artifacts/prd.md)
+- **Feature specs:** [docs/planning-artifacts/specs/](./planning-artifacts/specs/)
+- **Project overview:** [docs/project-overview-pdr.md](./project-overview-pdr.md)

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -1,0 +1,306 @@
+# Lumina-Wiki — System Architecture
+
+**Document Type:** Locked v0.1 Architecture  
+**Last Updated:** 2026-05-06  
+**Status:** Stable; breaking changes require SemVer major bump
+
+---
+
+## Two-Layer Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   NPM INSTALLER LAYER                   │
+│              (bin/lumina.js + src/installer/)            │
+│                                                          │
+│  • Entry: bin/lumina.js (lazy-imports subcommands)       │
+│  • Commands: install, upgrade, uninstall, --version      │
+│  • Core modules:                                         │
+│    - commands.js (18-step orchestration)                 │
+│    - fs.js (atomic writes, symlink ladder)               │
+│    - manifest.js (version tracking)                      │
+│    - template-engine.js (render {{var}} + {{#if}})       │
+│    - prompts.js (@clack/prompts interactive UX)          │
+│  • Output: Workspace directory structure + config files  │
+│  • Runs once per project (install/upgrade)               │
+└─────────────────────────────────────────────────────────┘
+                           ↓
+                  (projects workspace)
+                           ↓
+┌─────────────────────────────────────────────────────────┐
+│              WORKSPACE PAYLOAD LAYER                     │
+│     (src/scripts/*.mjs + src/tools/*.py + skills)        │
+│                                                          │
+│  Consumed by agent skills invoked via Bash + JSON:       │
+│                                                          │
+│  • wiki.mjs — graph/frontmatter mutations [only path]    │
+│  • lint.mjs — schema validation (9 checks)               │
+│  • reset.mjs — scoped destructive operations             │
+│  • discover-runner.mjs — scheduled research automation   │
+│  • tools/*.py — PDF extraction, research fetchers        │
+│  • skills/*.md — agent prompts (14 total)                │
+│                                                          │
+│  • Workspace directories:                                │
+│    - wiki/ (LLM-maintained knowledge graph)              │
+│    - raw/ (user inputs, read-only by default)            │
+│    - _lumina/ (framework config, scripts, state)         │
+│    - .agents/ or .claude/ (skill symlinks)                │
+│                                                          │
+│  • Single source of truth: schemas.mjs                   │
+│    (entity types, 28 edge types, frontmatter spec,       │
+│     exemption globs; consumed by wiki.mjs + lint.mjs)    │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Installer Flow (18 Steps, `src/installer/commands.js`)
+
+Top-level shape (detailed rationale in [docs/planning-artifacts/architecture.md](./planning-artifacts/architecture.md)):
+
+1. **Read manifest** — Fresh install or upgrade? Check `_lumina/manifest.json`
+2. **Interactive prompts** (fresh only) — IDE choice, pack selection (core forced-in)
+3. **Apply CLI overrides** — Merge `--yes`, `--packs`, `--ide` flags
+4. **Validate pack set** — Ensure `core` is included, fetch spec for each
+5. **Render README** — Generate canonical agent-context file (only region between markers updated on upgrade)
+6. **Render IDE stubs** — Create CLAUDE.md, AGENTS.md, GEMINI.md, .cursor/rules/lumina.mdc (~5 lines each)
+7. **Render config files** — `_lumina/config/lumina.config.yaml`, `.env.example`
+8. **Expand template tree** — waltz over `src/templates/` with pack-aware conditions
+9. **Write workspace files** — All via `atomicWrite()` to prevent torn writes
+10. **Create skill directories** — One per skill under `.claude/skills/lumi-<name>/` or `.agents/skills/`
+11. **Symlink skills** — Per-target (Claude Code vs Codex vs Cursor vs Gemini): symlink ladder
+    - Try: `symlink`
+    - Fall back: `junction` (Windows)
+    - Fall back: `copy` (Windows w/o Dev Mode, network drives)
+12. **Persist symlink strategy** — Record chosen ladder in `manifest.symlinkStrategies` for idempotent re-use
+13. **Write manifest** — `_lumina/manifest.json` (atomic, last write)
+14. **Write state files** — `_lumina/_state/skills-manifest.csv`, `files-manifest.csv` (atomic)
+15. **Git init** (if needed) — Ensure `.gitignore` references `_lumina/_state/`, `raw/tmp/`
+16. **Tree summary** — TTY-aware colorized directory tree
+17. **Upgrade migration** (if applicable) — Run `/lumi-migrate-legacy` or prompt user
+18. **Exit 0** — Success
+
+**Idempotency:** Install twice → `git diff` over watched paths (`README.md`, `CLAUDE.md`, `_lumina/config/`, `wiki/`, `raw/`, etc.) must be empty.
+
+---
+
+## Workspace Contract: Single Source of Truth
+
+**`src/scripts/schemas.mjs`** (pure data, no I/O):
+
+```javascript
+export const entityTypes = {
+  source: {
+    dirs: ['wiki/sources/'],
+    frontmatterRequired: ['title', 'urls', 'summary', 'tags'],
+    frontmatterOptional: ['authors', 'date', 'ingest_status', ...]
+  },
+  concept: {
+    dirs: ['wiki/concepts/'],
+    frontmatterRequired: ['title', 'definition', 'tags'],
+    ...
+  },
+  // ... person, summary, topic, plus pack-specific types
+}
+
+export const edgeTypes = [
+  { name: 'cites', reverse: 'cited_by', directed: true },
+  { name: 'defines', reverse: 'defined_by', directed: true },
+  { name: 'relates_to', reverse: 'relates_to', directed: false },
+  // ... 28 total edge definitions
+]
+
+export const exemptionGlobs = [
+  'foundations/**',     // Forward-only (no reverse required)
+  'outputs/**',
+  '*://*'               // External URLs
+]
+```
+
+**Both downstream modules import from `schemas.mjs`:**
+
+- **`wiki.mjs`:** Enforces schema on page create/mutate. Validates frontmatter, link types, bidirectional reverse writes.
+- **`lint.mjs`:** Validates pages against schema. 9 checks (L01–L09) include slug format, missing reverses, required fields, exemption compliance.
+
+**Change propagation:** If you add an edge type, both `wiki.mjs` and `lint.mjs` immediately recognize it (no separate updates needed).
+
+---
+
+## Write Paths (Atomicity Discipline)
+
+```
+┌─────────────────────────────┐
+│   Graph Mutations (SSOT)    │
+├─────────────────────────────┤
+│                             │
+│  wiki.mjs (only path)       │
+│  • Create page              │
+│  • Mutate frontmatter       │
+│  • Write bidirectional link │
+│  • Append to log.md         │
+│  • Rebuild graph/           │
+│                             │
+│  Skills → Bash + JSON       │
+│  (never import wiki.mjs)    │
+│                             │
+└─────────────────────────────┘
+                ↓
+       All writes atomic:
+       temp + fsync + rename
+                ↓
+    ┌─────────────────────┐
+    │   lint.mjs --fix    │
+    │ (repair 6 checks)   │
+    └─────────────────────┘
+                ↓
+    ┌─────────────────────┐
+    │  reset.mjs (delete) │
+    │ --scope {all|wiki}  │
+    └─────────────────────┘
+```
+
+**Contract:**
+- `wiki.mjs read` — JSON to stdout (never mutates)
+- `wiki.mjs create/mutate` — Atomic, JSON status to stdout, errors to stderr (exit 2/3)
+- `lint.mjs --fix` — Repairs L01–L07 atomically; L08/L09 advisory only
+- `reset.mjs --scope all` — Deletes `wiki/` and `_lumina/_state/` (never `raw/`)
+
+---
+
+## Symlink Ladder (Cross-Platform Strategy)
+
+**Problem:** Windows symlinks require Developer Mode; some network drives don't support symlinks.
+
+**Solution:** Per-skill, per-target, try three strategies in order:
+
+```javascript
+// src/installer/fs.js → symlinkWithFallback()
+
+async function symlinkWithFallback(sourceDir, linkPath, targetLabel) {
+  try {
+    // 1. Try native symlink
+    await symlink(sourceDir, linkPath, 'dir')
+    return 'symlink'
+  } catch (e) {
+    if (isWindows) {
+      try {
+        // 2. Try junction (Windows-only; no Dev Mode needed)
+        await symlink(sourceDir, linkPath, 'junction')
+        return 'junction'
+      } catch {
+        // 3. Fall back: copy entire directory
+        await copyDirRecursive(sourceDir, linkPath)
+        return 'copy'
+      }
+    }
+    throw e
+  }
+}
+```
+
+**Recorded in manifest:** `manifest.symlinkStrategies` maps each skill to its chosen strategy. On upgrade, re-use same strategy (idempotent).
+
+```json
+{
+  "symlinkStrategies": {
+    ".claude/skills/lumi-init": "symlink",
+    ".claude/skills/lumi-ingest": "junction",
+    ".agents/skills/lumi-discover": "copy"
+  }
+}
+```
+
+---
+
+## Entry-Point Stub Pattern
+
+**Principle:** Single source of truth (`README.md`) rather than filesystem tricks.
+
+```
+┌───────────────────────────┐
+│    README.md (root)       │
+│  [Canonical agent context]│
+│  • Schema overview        │
+│  • Skill directory        │
+│  • Workflow description   │
+│  • Links to _lumina/ docs │
+│                           │
+│  {{var}} placeholders:    │
+│  {{configured_ides}},     │
+│  {{installed_packs}},     │
+│  {{installed_skill_count}}│
+└───────────────────────────┘
+        ↑         ↑
+        │         │
+   (rendered once at install time)
+        │         │
+        ↓         ↓
+┌─────────────────────┐
+│  CLAUDE.md (stub)   │ ← Agent reads this → redirects to README.md
+│  AGENTS.md (stub)   │
+│  GEMINI.md (stub)   │
+│  .cursor/lumina.mdc │
+└─────────────────────┘
+```
+
+**Why not symlinks for README?** Because:
+- Symlinks to Markdown would require rendering on the agent side (complexity).
+- Users often edit README (e.g., add org notes); symlink would break in upstream updates.
+- One copy is more intuitive than "read the symlink target."
+
+**On upgrade:** Only the region between `<!-- lumina:schema -->` ... `<!-- /lumina:schema -->` markers is rewritten. User notes outside this region are preserved.
+
+**Stub files:** Always regenerated; ~5 lines each. Safe because they're not user-edited.
+
+---
+
+## Pack System
+
+**Core pack (always installed):**
+- 6 skills: `/lumi-init`, `/lumi-ingest`, `/lumi-ask`, `/lumi-edit`, `/lumi-check`, `/lumi-reset`
+- No Python deps
+
+**Research pack (opt-in):**
+- 4 skills: `/lumi-discover`, `/lumi-survey`, `/lumi-prefill`, `/lumi-research-topic`
+- Python tools: `prepare_source.py` (local source prep: .pdf, .tex, .html, .md, .txt), `discover.py`, `fetch_arxiv.py`, `fetch_s2.py`, `fetch_wikipedia.py`, `fetch_deepxiv.py`
+- Requires `requests>=2.31`, `pypdf>=4.0`
+
+**Reading pack (opt-in):**
+- 4 skills: `/lumi-chapter-ingest`, `/lumi-character-track`, `/lumi-theme-map`, `/lumi-plot-recap`
+- No additional Python deps
+
+**Pack selection logic** (in `commands.js` step 3):
+```javascript
+// core is always force-inserted
+const uniquePacks = ['core', ...userPacks]
+const dedupedPacks = [...new Set(uniquePacks)]
+// Result: core + research + reading = 14 skills total
+```
+
+---
+
+## Exit Code Contract
+
+All tools & installer honor:
+
+| Code | Meaning | Usage |
+|------|---------|-------|
+| `0` | Success | All operations completed successfully |
+| `1` | User error | Bad arguments, missing required flags, invalid slug |
+| `2` | Path safety / filesystem / unknown resource | `safePath()` rejection, file not found, `--scope` mismatch |
+| `3` | Internal / unexpected error | Corrupted manifest, JSON parse failure, race condition, network timeout (5xx) |
+| `4` | User cancellation | Ctrl-C in interactive prompt or declined confirm |
+
+**Example:** `safePath('../../etc/passwd')` raises `RangeError` → caught at `bin/lumina.js` → exit 2.
+
+---
+
+## See Also
+
+- **Project vision & scope:** [docs/project-overview-pdr.md](./project-overview-pdr.md)
+- **Codebase map:** [docs/codebase-summary.md](./codebase-summary.md)
+- **Code standards & rules:** [docs/code-standards.md](./code-standards.md)
+- **Locked v0.1 decisions:** [docs/planning-artifacts/architecture.md](./planning-artifacts/architecture.md)
+- **Full PRD:** [docs/planning-artifacts/prd.md](./planning-artifacts/prd.md)
+- **Development guide:** [docs/DEVELOPMENT.md](./DEVELOPMENT.md)
+- **Critical agent rules:** [docs/project-context.md](./project-context.md)


### PR DESCRIPTION
## Summary

- **`docs/code-standards.md`** (new) — non-negotiable rules, naming conventions, exit-code contract (0/1/2/3/4), pre-push checklist, wiki invariants.
- **`docs/codebase-summary.md`** (new) — repo structure, module LOC breakdown, write paths, Python deps inventory.
- **`docs/project-context.md`** — added exit code 4 (user cancellation) to the rule list.
- **`docs/project-overview-pdr.md`** (new) — vision, problem/solution, scope, components, release history.
- **`docs/project-roadmap.md`** (new) — current release highlights, near-term/long-term features; CLI Stability Lock items marked Shipped v1.x.
- **`docs/system-architecture.md`** (new) — two-layer diagram, 18-step installer flow, exit-code table (incl. 4), pack system.