### PR TITLE
fix(learning-pack): post-merge follow-up — Codex review findings + CI assert.rejects

### DIFF
--- a/src/installer/commands.test.js
+++ b/src/installer/commands.test.js
@@ -128,8 +128,8 @@ describe('installCommand', () => {
       assert.equal(result.status, 0, result.stderr);
       const config = await readFile(join(workspace, '_lumina', 'config', 'lumina.config.yaml'), 'utf8');
       assert.match(config, /learning: false/);
-      await assert.rejects(access(join(workspace, 'wiki', 'reflections')));
-      await assert.rejects(access(join(workspace, '.agents', 'skills', 'lumi-learning-reflect')));
+      await assert.rejects(() => access(join(workspace, 'wiki', 'reflections')));
+      await assert.rejects(() => access(join(workspace, '.agents', 'skills', 'lumi-learning-reflect')));
     } finally {
       await cleanTmp(tmp);
     }

--- a/src/installer/locales/en.mjs
+++ b/src/installer/locales/en.mjs
@@ -37,6 +37,8 @@ export default {
   'prompt.packs.option.research.hint':         'discover/survey/prefill/setup skills + source-fetcher tools',
   'prompt.packs.option.reading.label':         'Reading',
   'prompt.packs.option.reading.hint':          'chapter-ingest/character-track/theme-map/plot-recap skills',
+  'prompt.packs.option.learning.label':        'Learning',
+  'prompt.packs.option.learning.hint':         'self-reflection skills (reflect skill + wiki/reflections/)',
 
   // ── Language pair ──────────────────────────────────────────────────────────
   'prompt.communication_language.message':     'Communication language (how the LLM talks to you)',

--- a/src/installer/locales/vi.mjs
+++ b/src/installer/locales/vi.mjs
@@ -36,6 +36,8 @@ export default {
   'prompt.packs.option.research.hint':         'kỹ năng discover/survey/prefill/setup + công cụ lấy nguồn',
   'prompt.packs.option.reading.label':         'Reading',
   'prompt.packs.option.reading.hint':          'kỹ năng chapter-ingest/character-track/theme-map/plot-recap',
+  'prompt.packs.option.learning.label':        'Learning',
+  'prompt.packs.option.learning.hint':         'kỹ năng tự phản tư (reflect + wiki/reflections/)',
 
   // ── Language pair ──────────────────────────────────────────────────────────
   'prompt.communication_language.message':     'Ngôn ngữ giao tiếp (LLM trò chuyện với bạn)',

--- a/src/installer/locales/zh.mjs
+++ b/src/installer/locales/zh.mjs
@@ -42,6 +42,8 @@ export default {
   'prompt.packs.option.research.hint':         'discover/survey/prefill/setup 技能 + 来源抓取工具',
   'prompt.packs.option.reading.label':         'Reading',
   'prompt.packs.option.reading.hint':          'chapter-ingest/character-track/theme-map/plot-recap 技能',
+  'prompt.packs.option.learning.label':        'Learning',
+  'prompt.packs.option.learning.hint':         '自我反思技能 (reflect 技能 + wiki/reflections/)',
 
   // ── Language pair ──────────────────────────────────────────────────────────
   'prompt.communication_language.message':     '交流语言(LLM 与你对话使用的语言)',

--- a/src/installer/prompts.js
+++ b/src/installer/prompts.js
@@ -241,6 +241,7 @@ export async function runInstallPrompts({ acceptDefaults = false, cwd = process.
     options: [
       { value: 'research', label: t ? t('prompt.packs.option.research.label') : 'Research', hint: t ? t('prompt.packs.option.research.hint') : 'discover/survey/prefill/setup skills + source-fetcher tools' },
       { value: 'reading',  label: t ? t('prompt.packs.option.reading.label') : 'Reading',   hint: t ? t('prompt.packs.option.reading.hint') : 'chapter-ingest/character-track/theme-map/plot-recap skills' },
+      { value: 'learning', label: t ? t('prompt.packs.option.learning.label') : 'Learning', hint: t ? t('prompt.packs.option.learning.hint') : 'self-reflection skills (reflect skill + wiki/reflections/)' },
     ],
     required: false,
   });

--- a/src/scripts/lint.mjs
+++ b/src/scripts/lint.mjs
@@ -1285,7 +1285,7 @@ async function applyFixes(findings, wikiRoot, edgesPath, indexPath, indexContent
   // Fix L09.
   const l09findings = findings.filter(f => f.id === 'L09-index-stale');
   if (l09findings.length > 0) {
-    const { newContent, preview } = fixL09(indexContent, entityFiles);
+    const { newContent, preview } = fixL09(indexContent, entityFiles.filter(f => !f.startsWith('reflections/')));
     if (newContent !== indexContent) {
       if (opts.dryRun) {
         for (const f of l09findings) { f.proposed_fix = preview; }


### PR DESCRIPTION
## Summary

Two commits that were missed before PR #16 was merged:

- **`fix(ci): wrap assert.rejects calls in arrow functions`** — avoids unhandled rejection race in test suite
- **`fix(learning-pack): address Codex review findings`** — two P2 findings from Codex bot review:
  - `src/installer/prompts.js`: add `learning` pack option to interactive multiselect (was in `VALID_PACKS` but unreachable via interactive install)
  - `src/scripts/lint.mjs`: fix L09 fix-path asymmetry — `applyFixes` now applies the same `reflections/` filter as `checkL09` so `lint --fix` doesn't pollute `wiki/index.md`
  - Locale keys added for en/vi/zh

## Test plan

- [x] `npm run test:all` — 191 installer + 278 scripts + 304 Python = 773 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)