### PR TITLE
fix(installer): rebind translator after locale prompt

### DIFF
--- a/src/installer/prompts.js
+++ b/src/installer/prompts.js
@@ -151,13 +151,18 @@ export function buildPromptList(existingManifest, defaultLocale = 'en') {
  * @param {Function} [opts.t]                   - Locale translator function.
  * @returns {Promise<InstallAnswers>}
  */
-export async function runInstallPrompts({ acceptDefaults = false, cwd = process.cwd(), existingManifest = null, defaultLocale = 'en', t = null } = {}) {
+export async function runInstallPrompts({ acceptDefaults = false, cwd = process.cwd(), existingManifest = null, defaultLocale = 'en', t: initialT = null } = {}) {
   if (acceptDefaults) {
     const loc = existingManifest?.locale ?? defaultLocale;
     return defaultAnswers(cwd, loc);
   }
 
   const { intro, outro, text, multiselect, select, confirm, isCancel, cancel } = await getClack();
+
+  // t starts as whatever the caller passed (may be null on fresh install where
+  // locale is unknown). After Prompt 0 selects the locale, we rebind t to the
+  // user-chosen locale so prompts 1-5 are localized.
+  let t = initialT;
 
   // t may not be available yet at intro time (locale not yet selected);
   // use hardcoded EN for intro — this is the chicken-and-egg prompt.
@@ -178,6 +183,17 @@ export async function runInstallPrompts({ acceptDefaults = false, cwd = process.
   }
   const locale = localeRaw;
   const langDefault = LOCALE_LANGUAGE_NAME[locale] ?? 'English';
+
+  // Rebind t to the just-selected locale so the remaining prompts render in
+  // the user's chosen language. Without this, prompts 1-5 silently fall back
+  // to EN literals even when the user picked vi/zh at Prompt 0.
+  try {
+    const { loadLocale } = await import('./locales.js');
+    const localeMod = await loadLocale(locale);
+    t = localeMod.t;
+  } catch {
+    // Keep whatever t we had (possibly null → EN literals); never block install.
+  }
 
   // Interactive locale-switch confirmation (Phase 5 §60-63):
   // If user picks a locale different from the installed one on an upgrade,

--- a/src/installer/prompts.js
+++ b/src/installer/prompts.js
@@ -201,8 +201,9 @@ export async function runInstallPrompts({ acceptDefaults = false, cwd = process.
   // and IDE stubs. Default N — protects user content.
   if (existingManifest?.locale && existingManifest.locale !== locale) {
     const proceed = await confirm({
-      // Use trilingual literal — t() not yet bound to chosen locale and the
-      // user is mid-switch; both old and new locales are relevant context.
+      // Use trilingual literal — user is mid-switch, so both old and new
+      // locales are relevant context. t() is available here but intentionally
+      // not used so the warning is legible in either locale.
       message: `Locale change ${existingManifest.locale} -> ${locale} will rewrite README.md and IDE stubs in the new locale. Outside-schema edits are preserved. Continue?`,
       initialValue: false,
     });


### PR DESCRIPTION
## Summary

On fresh interactive install, picking **Tiếng Việt** or **中文** at the locale prompt still rendered the rest of the prompts (directory, research purpose, IDE targets, packs, communication/document language) in English.

## Root cause

`commands.js` calls `runInstallPrompts` before any locale is known on a fresh install, so `t` is passed as `null`. Inside `runInstallPrompts`, Prompt 0 collects the locale — but `t` is never rebound. Every subsequent prompt has the shape `t ? t('key') : 'English literal'`, so it silently falls back to EN even though the user explicitly picked a non-EN locale.

This is why only the final summary line (`Đã cài đặt Lumina Wiki thành công`) localizes — that translator is loaded *after* prompts finish, back in `commands.js`.

## Fix

- `t` parameter renamed to `initialT` and rebound to a local `let t` inside `runInstallPrompts`.
- After Prompt 0 resolves the locale, lazy-import `./locales.js` and call `loadLocale(locale)` to bind `t` to the chosen locale.
- Wrapped in `try/catch` so a corrupt locale module never blocks the install — falls through to existing EN literals.

No new dependencies, no changes to call sites, no schema/manifest changes.

## Test plan

- [x] `npm run test:installer` — 178/178 pass
- [x] `npm run dev:sandbox` (non-interactive `--yes` path) — install summary still localizes correctly
- [ ] Manual interactive verification: run `npm run dev:sandbox` without `--yes`, pick Tiếng Việt, confirm prompts 1-5 render in Vietnamese
- [ ] Manual interactive verification: same flow with 中文