### PR TITLE
[codex] fix Node test runner IPC flake on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,6 @@ jobs:
   installability:
     name: Node ${{ matrix.node-version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    # Windows hosted runners hit a flaky node:test IPC failure
-    # (uncaughtException / ERR_TEST_FAILURE in
-    # node:internal/test_runner/runner) on commands.test.js, even on Node 20.
-    # The bug is intermittent (same SHA passes on re-run) and originates in
-    # the Node runtime, not in lumina-wiki code. Mark Windows as
-    # continue-on-error so flakes surface as warnings without blocking the
-    # build; tracked separately for a real fix.
-    continue-on-error: ${{ matrix.experimental == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -31,9 +23,6 @@ jobs:
         # ubuntu). Stay on Node 20 across all OSes until the upstream fix
         # lands; revisit when Node 22.x patches the runner IPC.
         node-version: [20]
-        include:
-          - os: windows-latest
-            experimental: true
 
     steps:
       - name: Checkout

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
   "devDependencies": {},
   "scripts": {
     "test": "npm run test:installer",
-    "test:installer": "node --test bin/lumina.flags.test.js bin/lumina.deprecations.test.js bin/lumina.cancel.test.js src/installer/commands.test.js src/installer/fs.test.js src/installer/locales.test.js src/installer/manifest.test.js src/installer/prompts.test.js src/installer/readme-templates.test.js src/installer/template-engine.test.js src/installer/update-check.test.js",
+    "test:installer": "npm run test:installer:commands && node --test bin/lumina.flags.test.js bin/lumina.deprecations.test.js bin/lumina.cancel.test.js src/installer/fs.test.js src/installer/locales.test.js src/installer/manifest.test.js src/installer/prompts.test.js src/installer/readme-templates.test.js src/installer/template-engine.test.js src/installer/update-check.test.js",
+    "test:installer:commands": "node src/installer/commands.test.js",
     "test:scripts": "node --test src/scripts/lint.test.mjs src/scripts/reset.test.mjs src/scripts/wiki.test.mjs src/scripts/discover-runner.test.mjs src/scripts/external-ids.test.mjs src/scripts/parse-ids.test.mjs src/scripts/merge-ids.test.mjs src/scripts/build-source.test.mjs src/scripts/wiki-yaml-object.test.mjs src/scripts/schemas.test.mjs",
     "test:python": "node scripts/run-pytest.mjs",
     "test:all": "npm run test:installer && npm run test:scripts && npm run test:python",

--- a/src/installer/commands.test.js
+++ b/src/installer/commands.test.js
@@ -1,5 +1,10 @@
 /**
  * Tests for src/installer/commands.js high-risk install behavior.
+ *
+ * Run this file directly with Node, as configured in package.json. Several
+ * tests intentionally emit localized installer output; Node 20's parent test
+ * runner multiplexes that output with its serialized protocol and can
+ * intermittently misparse the stream (GitHub issue #23).
  */
 
 import { test, describe } from 'node:test';


### PR DESCRIPTION
## Summary

- run `src/installer/commands.test.js` directly with Node instead of through the parent `node --test` worker runner
- keep the remaining installer tests on the normal parallel test runner
- remove the Windows `continue-on-error` matrix exception so failures block CI again

## Root cause

Node 20's parent test runner multiplexes serialized test protocol messages and test-file stdout on the same pipe. `commands.test.js` intentionally emits localized installer output, which can intermittently be misparsed as a serialized frame and fail with `ERR_TEST_FAILURE` before test results are reported.

Running this test file directly preserves its `node:test` coverage while removing the affected parent/child IPC parser from this path.

## Validation

- `commands.test.js`: 20 consecutive direct runs passed
- `npm run test:installer`: 159 tests passed
- `npm run test:scripts`: 284 tests passed
- `npm run ci:idempotency`: passed all scenarios
- `npm run ci:package`: passed

Python tests were not affected by this change. The local environment passed 431 tests; six RSS tests require the missing `feedparser` dependency, which CI installs from `src/tools/requirements.txt`.

Closes #23