### PR TITLE
fix(installer): reconcile upgrade state

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The agent will help you check the research tools and save keys to a local `.env`
 
 If you reinstall Lumina-Wiki on a project that already has a `wiki/` from an earlier version, just run `npx lumina-wiki install` again. The installer updates scripts, schemas, and skills; **your content in `wiki/`, `raw/`, and `log.md` is not modified**.
 
+You can run the command from the project root or one of its subfolders. If you remove a pack or AI tool from the setup, Lumina removes its old managed commands and unchanged setup files. Files you edited are kept with a warning. If the whole project was copied, moved, or renamed, Lumina repairs its managed links during the upgrade.
+
 If the installer warns that older entries are missing newer frontmatter fields, you have two ways to backfill them:
 
 - **Recommended:** open your AI chat and run `/lumi-migrate-legacy`.

--- a/README.vi.md
+++ b/README.vi.md
@@ -93,6 +93,8 @@ Agent sẽ hướng dẫn bạn kiểm tra công cụ nghiên cứu và lưu key
 
 Nếu bạn cài lại Lumina-Wiki trên một dự án đã có `wiki/` từ phiên bản trước, cứ chạy lại `npx lumina-wiki install`. Installer cập nhật scripts, schemas và skills; **nội dung của bạn trong `wiki/`, `raw/`, `log.md` không bị chỉnh sửa**.
 
+Bạn có thể chạy lệnh tại thư mục gốc hoặc một thư mục con của dự án. Nếu bỏ một gói hoặc công cụ AI khỏi thiết lập, Lumina sẽ dọn các lệnh cũ và những tệp thiết lập chưa được bạn sửa. Tệp đã chỉnh sửa được giữ lại kèm cảnh báo. Nếu toàn bộ dự án được sao chép, di chuyển hoặc đổi tên, Lumina sẽ sửa lại các liên kết do hệ thống quản lý khi nâng cấp.
+
 Nếu installer cảnh báo entry cũ thiếu frontmatter mới, có hai cách backfill:
 
 - **Khuyến nghị:** mở chat AI và chạy `/lumi-migrate-legacy`.

--- a/README.zh.md
+++ b/README.zh.md
@@ -93,6 +93,8 @@ Agent 会引导您检查研究工具，并在需要时把 key 保存到本地 `.
 
 如果您在已经有旧版 `wiki/` 的项目上重新安装 Lumina-Wiki，直接再次运行 `npx lumina-wiki install` 即可。安装器会更新 scripts、schemas 和 skills；**您在 `wiki/`、`raw/`、`log.md` 中的内容不会被修改**。
 
+您可以在项目根目录或其子目录中运行该命令。如果从设置中移除某个包或 AI 工具，Lumina 会清理旧命令和未经您修改的设置文件。您修改过的文件会保留，并显示警告。如果整个项目被复制、移动或重命名，Lumina 会在升级时修复由系统管理的链接。
+
 如果安装器提示旧条目缺少新的 frontmatter 字段，可以用两种方式回填：
 
 - **推荐：** 打开 AI 对话并运行 `/lumi-migrate-legacy`。

--- a/bin/lumina.js
+++ b/bin/lumina.js
@@ -199,6 +199,12 @@ program
   .option('--force-locale-switch', 'allow switching installer locale during upgrade')
   .action(async (cmdOpts) => {
     const globalOpts = program.opts();
+    const hasExplicitDirectory = (
+      cmdOpts.directory != null
+      || cmdOpts.cwd != null
+      || globalOpts.directory != null
+      || globalOpts.cwd != null
+    );
     const mergedDir      = cmdOpts.directory ?? cmdOpts.cwd ?? globalOpts.directory ?? globalOpts.cwd ?? process.cwd();
     const mergedYes      = cmdOpts.yes      ?? globalOpts.yes      ?? false;
     const mergedReLink   = cmdOpts.reLink   ?? globalOpts.reLink   ?? false;
@@ -220,6 +226,7 @@ program
         documentOutputLang: cmdOpts.documentOutputLanguage,
         lang: cmdOpts.lang,
         forceLocaleSwitch: Boolean(cmdOpts.forceLocaleSwitch),
+        searchParents: !hasExplicitDirectory,
       });
     } catch (err) {
       // Top-level catch: locale may not be resolved yet (pre-loadLocale path).

--- a/docs/user-guide/en.md
+++ b/docs/user-guide/en.md
@@ -500,6 +500,8 @@ npx lumina-wiki install
 
 The installer will update scripts, schemas, and skills. Your knowledge content in `wiki/`, original documents in `raw/`, and existing log are preserved.
 
+You may run the command from the project root or from a folder inside it. Lumina will find the enclosing workspace. When you remove a pack or AI tool from the setup, its old managed commands and unchanged setup files are removed. Files you changed are kept and reported. Moving, renaming, or copying the whole project is also supported; managed links are repaired on the next upgrade.
+
 If an old wiki is missing some new metadata fields, the installer may warn you. In that case, you can run:
 
 ```text

--- a/docs/user-guide/vi.md
+++ b/docs/user-guide/vi.md
@@ -558,6 +558,8 @@ npx lumina-wiki install
 
 Installer sẽ cập nhật script, schema và skill. Nội dung tri thức của bạn trong `wiki/`, tài liệu gốc trong `raw/`, và log hiện có được giữ lại.
 
+Bạn có thể chạy lệnh tại thư mục gốc hoặc một thư mục nằm bên trong project; Lumina sẽ tìm đúng không gian làm việc bao quanh. Khi bỏ một gói hoặc công cụ AI khỏi thiết lập, các lệnh cũ và tệp thiết lập chưa được chỉnh sửa sẽ được dọn đi. Tệp bạn đã sửa được giữ lại và báo rõ. Bạn cũng có thể di chuyển, đổi tên hoặc sao chép toàn bộ project; các liên kết do Lumina quản lý sẽ được sửa trong lần nâng cấp tiếp theo.
+
 Nếu wiki cũ thiếu một số trường metadata mới, installer có thể cảnh báo. Khi đó bạn có thể chạy:
 
 ```text

--- a/docs/user-guide/zh.md
+++ b/docs/user-guide/zh.md
@@ -496,6 +496,8 @@ npx lumina-wiki install
 
 Installer 会更新 script、schema 和 skill。你在 `wiki/` 中的知识内容、`raw/` 中的原始资料，以及已有日志都会保留下来。
 
+你可以在项目根目录或其中的子目录运行该命令，Lumina 会找到外层工作区。当你从设置中移除某个包或 AI 工具时，其旧命令和未经修改的设置文件会被清理。你修改过的文件会保留并明确提示。你也可以移动、重命名或复制整个项目；Lumina 管理的链接会在下次升级时修复。
+
 如果旧 wiki 缺少一些新的 metadata 字段，installer 可能会给出警告。此时你可以运行：
 
 ```text

--- a/src/installer/commands.js
+++ b/src/installer/commands.js
@@ -249,7 +249,7 @@ export async function installCommand(opts = {}) {
     if (
       installedLocale !== answers.locale
       && !opts.forceLocaleSwitch
-      && !answers.localeSwitchConfirmed
+      && answers.localeSwitchConfirmedFor !== answers.locale
     ) {
       const e = new Error(
         `LOCALE_SWITCH_REFUSED: installed locale '${installedLocale}' differs from resolved locale '${answers.locale}'. ` +
@@ -749,7 +749,9 @@ function applyInstallOverrides(answers, opts) {
   const next = { ...answers };
   const priorLocale = answers.locale ?? null;
 
-  // Locale: --lang flag overrides; case-insensitive normalize.
+  // Locale: --lang overrides the interactive selector. Keep the installed
+  // locale in answers.locale until this point so default language values can
+  // cascade correctly when an existing destination is selected.
   // Pre-loadLocale error → EN-only string (chicken-and-egg, machine-readable).
   if (opts.lang !== undefined && opts.lang !== null && opts.lang !== '') {
     const normalized = String(opts.lang).toLowerCase().trim();
@@ -759,9 +761,12 @@ function applyInstallOverrides(answers, opts) {
       throw e;
     }
     next.locale = normalized;
+  } else if (next.selectedLocale) {
+    next.locale = next.selectedLocale;
   } else if (!next.locale) {
     next.locale = 'en';
   }
+  delete next.selectedLocale;
 
   // Cascade: if --lang changed locale and user didn't explicitly pass language
   // overrides, refresh the language defaults to match the new locale.

--- a/src/installer/commands.js
+++ b/src/installer/commands.js
@@ -127,6 +127,37 @@ const LUMINA_DIRS = [
 
 const VALID_PACKS = new Set(['core', 'research', 'reading', 'learning']);
 const VALID_IDE_TARGETS = new Set(['claude_code', 'codex', 'cursor', 'gemini_cli', 'qwen', 'iflow', 'generic']);
+const RESEARCH_TOOL_FILES = [
+  '_env.py', '_cache.py', 'discover.py', 'init_discovery.py', 'prepare_source.py',
+  'fetch_arxiv.py', 'fetch_wikipedia.py', 'fetch_s2.py', 'fetch_deepxiv.py',
+  'fetch_openalex.py', 'fetch_unpaywall.py', 'fetch_core.py', 'resolve_pdf.py',
+  'fetch_rss.py',
+];
+
+async function findEnclosingWorkspace(startDir) {
+  let current = resolve(startDir);
+  while (true) {
+    try {
+      await access(join(current, '_lumina', 'manifest.json'), fsConstants.F_OK);
+      return current;
+    } catch (err) {
+      if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') throw err;
+    }
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+async function readManifestForInstall(projectRoot) {
+  try {
+    return await readManifest(projectRoot);
+  } catch (err) {
+    const e = new Error(`MANIFEST_READ_FAILED: ${err.message} (path: ${projectRoot}/_lumina/manifest.json)`);
+    e.code = 2;
+    throw e;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // install command
@@ -144,32 +175,24 @@ const VALID_IDE_TARGETS = new Set(['claude_code', 'codex', 'cursor', 'gemini_cli
  * @param {string} [opts.projectName]  - Hidden escape hatch; default = basename(directory)
  * @param {string} [opts.communicationLang]
  * @param {string} [opts.documentOutputLang]
+ * @param {boolean} [opts.searchParents] - Find an enclosing Lumina workspace when no directory flag was used
  */
 export async function installCommand(opts = {}) {
   const { yes = false, reLink = false } = opts;
   const initialDir = opts.directory ?? opts.cwd ?? process.cwd();
-  let projectRoot = resolve(initialDir);
+  const requestedRoot = resolve(initialDir);
+  let projectRoot = opts.searchParents
+    ? (await findEnclosingWorkspace(requestedRoot) ?? requestedRoot)
+    : requestedRoot;
   const colors = await getColorFns();
 
   // 1. Read existing manifest at the initial path (upgrade detection)
   // Distinguish ENOENT (fresh install) from real I/O errors. Real errors must
   // bail loud — silently treating them as "fresh install" would let a transient
   // permission failure quietly nuke an existing install.
-  let existingManifest = null;
-  try {
-    existingManifest = await readManifest(projectRoot);
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      existingManifest = null;
-    } else {
-      // Pre-loadLocale path — intentionally EN-only and machine-readable.
-      const e = new Error(`MANIFEST_READ_FAILED: ${err.message} (path: ${projectRoot}/_lumina/manifest.json)`);
-      e.code = 2;
-      throw e;
-    }
-  }
+  let existingManifest = await readManifestForInstall(projectRoot);
 
-  const isUpgrade = existingManifest !== null;
+  let isUpgrade = existingManifest !== null;
 
   // 2. Collect answers (locale not yet loaded; prompts use EN fallback literals)
   let answers;
@@ -182,13 +205,27 @@ export async function installCommand(opts = {}) {
       cwd: projectRoot,
       existingManifest,
       defaultLocale: opts.lang ?? 'en',
+      resolveDestination: async (directory) => {
+        const manifest = await readManifestForInstall(directory);
+        if (!manifest) return null;
+        return {
+          existingManifest: manifest,
+          answers: await readAnswersFromConfig(directory, manifest),
+        };
+      },
     });
     // Re-resolve projectRoot from the directory the user typed.
     if (answers.directory) {
       projectRoot = resolve(answers.directory);
     }
+    existingManifest = await readManifestForInstall(projectRoot);
+    isUpgrade = existingManifest !== null;
   }
   answers = applyInstallOverrides(answers, opts);
+  const previousSkillRows = isUpgrade
+    ? previousManagedSkillRows(await readSkillsManifest(projectRoot), existingManifest)
+    : [];
+  const previousFileRows = isUpgrade ? await readFilesManifest(projectRoot) : [];
 
   // 2b. Load locale module ONCE after applyInstallOverrides resolves locale.
   const localeMod = await loadLocale(answers.locale ?? 'en');
@@ -209,7 +246,11 @@ export async function installCommand(opts = {}) {
         ?? migrateManifest(existingManifest, MANIFEST_SCHEMA_VERSION).locale
         ?? 'en'
     );
-    if (installedLocale !== answers.locale && !opts.forceLocaleSwitch) {
+    if (
+      installedLocale !== answers.locale
+      && !opts.forceLocaleSwitch
+      && !answers.localeSwitchConfirmed
+    ) {
       const e = new Error(
         `LOCALE_SWITCH_REFUSED: installed locale '${installedLocale}' differs from resolved locale '${answers.locale}'. ` +
         `Pass --force-locale-switch to confirm (this will rewrite README.md and IDE stubs in the new locale).`,
@@ -223,12 +264,18 @@ export async function installCommand(opts = {}) {
   const hasResearch = packs.includes('research');
   const hasReading  = packs.includes('reading');
   const hasLearning = packs.includes('learning');
+  const previousProjectRoot = existingManifest?.resolvedPaths?.projectRoot;
+  const relocated = Boolean(previousProjectRoot && resolve(previousProjectRoot) !== projectRoot);
+  const effectiveReLink = reLink || relocated;
 
   console.log('');
   if (isUpgrade) {
     console.log(colors.bold(t('progress.upgrading', { dir: projectRoot })));
   } else {
     console.log(colors.bold(t('progress.installing', { dir: projectRoot })));
+  }
+  if (relocated) {
+    console.log(colors.yellow(t('warn.relocated', { from: previousProjectRoot, to: projectRoot })));
   }
 
   // 3. Scaffold directories
@@ -250,6 +297,20 @@ export async function installCommand(opts = {}) {
 
   for (const dir of dirsToCreate) {
     await ensureDir(join(projectRoot, dir));
+  }
+
+  await reconcileRemovedIdeTargets({
+    projectRoot,
+    previousIdeTargets: existingManifest?.ideTargets ?? [],
+    currentIdeTargets: ideTargets,
+    previousFileRows,
+    previousSkillRows,
+    colors,
+    t,
+  });
+
+  if (isUpgrade && existingManifest?.packs?.research && !hasResearch) {
+    await cleanupRemovedResearchPack(projectRoot, previousFileRows, colors, t);
   }
 
   // 4. Template variables
@@ -282,7 +343,10 @@ export async function installCommand(opts = {}) {
   await copyChangelog(projectRoot);
 
   // 9. Copy skills
-  const skillRows = await copySkills(projectRoot, packs);
+  const skillRows = await copySkills(projectRoot, packs, {
+    claudeCode: ideTargets.includes('claude_code'),
+  });
+  await reconcileRemovedSkills(projectRoot, previousSkillRows, skillRows);
 
   // 10. Copy Python tools (core: extract_pdf; research pack: discovery/fetchers)
   await copyTools(projectRoot, { research: hasResearch });
@@ -307,10 +371,18 @@ export async function installCommand(opts = {}) {
   // 15. Create per-skill symlinks (.claude/skills/lumi-*) for Claude Code
   const symlinkStrategies = {};
   if (ideTargets.includes('claude_code')) {
-    const { strategies } = await createSkillSymlinks(
-      projectRoot, skillRows, existingManifest, reLink, colors, t
+    const { strategies, errors } = await createSkillSymlinks(
+      projectRoot, skillRows, existingManifest, effectiveReLink, colors, t
     );
     Object.assign(symlinkStrategies, strategies);
+    if (errors.length > 0) {
+      const e = new Error(
+        `SKILL_LINKS_INCOMPLETE: ${errors.length} of ${skillRows.length} Claude skill links failed: ` +
+        errors.map(item => `${item.skill}: ${item.error.message}`).join('; '),
+      );
+      e.code = 2;
+      throw e;
+    }
   }
 
   // 16. Build files-manifest rows
@@ -929,6 +1001,113 @@ function ideTargetStubFiles(ideTargets) {
     .filter(Boolean);
 }
 
+async function removeManagedFileIfUnchanged(projectRoot, relPath, previousFileRows, colors, t) {
+  const absPath = safePath(projectRoot, relPath);
+  try {
+    await access(absPath, fsConstants.F_OK);
+  } catch (err) {
+    if (err.code === 'ENOENT') return;
+    throw err;
+  }
+
+  const previous = previousFileRows.find(row => row.relative_path === relPath);
+  if (previous?.sha256) {
+    try {
+      if (await fileHash(absPath) === previous.sha256) {
+        await unlink(absPath);
+        return;
+      }
+    } catch (_) {}
+  }
+
+  console.log(colors.yellow(t('warn.preserved_modified_file', { path: relPath })));
+}
+
+function previousManagedSkillRows(previousSkillRows, existingManifest) {
+  const rowsById = new Map(previousSkillRows.map(row => [row.canonical_id, row]));
+  const previousStrategies = existingManifest?.symlinkStrategies ?? {};
+  const claudeWasSelected = existingManifest?.ideTargets?.includes('claude_code') ?? false;
+  const previousPacks = Object.keys(existingManifest?.packs ?? {});
+  for (const skill of getSkillDefs(previousPacks)) {
+    if (!rowsById.has(skill.canonicalId)) {
+      rowsById.set(skill.canonicalId, {
+        canonical_id: skill.canonicalId,
+        relative_path: join('.agents', 'skills', skill.canonicalId),
+        target_link_path: existingManifest?.ideTargets?.includes('claude_code')
+          ? join('.claude', 'skills', skill.canonicalId)
+          : '',
+      });
+    }
+  }
+  for (const canonicalId of Object.keys(previousStrategies)) {
+    if (!rowsById.has(canonicalId)) {
+      rowsById.set(canonicalId, {
+        canonical_id: canonicalId,
+        relative_path: join('.agents', 'skills', canonicalId),
+        target_link_path: join('.claude', 'skills', canonicalId),
+      });
+    }
+  }
+  return [...rowsById.values()].map(row => ({
+    ...row,
+    managed_link: claudeWasSelected
+      || Object.prototype.hasOwnProperty.call(previousStrategies, row.canonical_id),
+  }));
+}
+
+async function removeManagedSkillLink(projectRoot, skill) {
+  if (skill.managed_link === false) return;
+  const relPath = skill.target_link_path || join('.claude', 'skills', skill.canonical_id);
+  await rm(safePath(projectRoot, relPath), { recursive: true, force: true });
+}
+
+async function reconcileRemovedIdeTargets({
+  projectRoot,
+  previousIdeTargets,
+  currentIdeTargets,
+  previousFileRows,
+  previousSkillRows,
+  colors,
+  t,
+}) {
+  const removedTargets = previousIdeTargets.filter(target => !currentIdeTargets.includes(target));
+  for (const target of removedTargets) {
+    if (target === 'claude_code') {
+      await Promise.all(previousSkillRows.map(skill => removeManagedSkillLink(projectRoot, skill)));
+    }
+
+    const relPath = ideTargetStubFiles([target])[0];
+    if (relPath) {
+      await removeManagedFileIfUnchanged(projectRoot, relPath, previousFileRows, colors, t);
+    }
+  }
+}
+
+async function reconcileRemovedSkills(projectRoot, previousSkillRows, currentSkillRows) {
+  const currentIds = new Set(currentSkillRows.map(row => row.canonical_id));
+  const obsolete = previousSkillRows.filter(row => !currentIds.has(row.canonical_id));
+
+  for (const skill of obsolete) {
+    if (skill.relative_path) {
+      await rm(safePath(projectRoot, skill.relative_path), { recursive: true, force: true });
+    }
+    await removeManagedSkillLink(projectRoot, skill);
+  }
+}
+
+async function cleanupRemovedResearchPack(projectRoot, previousFileRows, colors, t) {
+  await Promise.all(RESEARCH_TOOL_FILES.map(file => (
+    rm(safePath(projectRoot, join('_lumina', 'tools', file)), { force: true })
+  )));
+  await removeManagedFileIfUnchanged(
+    projectRoot,
+    '.env.example',
+    previousFileRows,
+    colors,
+    t,
+  );
+}
+
 function buildIdeStub(target, vars) {
   const name = vars.project_name || 'this wiki';
   switch (target) {
@@ -983,7 +1162,7 @@ async function copyChangelog(projectRoot) {
   }
 }
 
-async function copySkills(projectRoot, packs) {
+async function copySkills(projectRoot, packs, { claudeCode = false } = {}) {
   const skillRows = [];
   const skillDefs = getSkillDefs(packs);
 
@@ -1003,7 +1182,7 @@ async function copySkills(projectRoot, packs) {
       pack:            skill.pack,
       source:          'built-in',
       relative_path:   `.agents/skills/${skill.canonicalId}`,
-      target_link_path: join('.claude', 'skills', skill.canonicalId),
+      target_link_path: claudeCode ? join('.claude', 'skills', skill.canonicalId) : '',
       version:         PKG.version,
     });
   }
@@ -1085,13 +1264,7 @@ function getSkillDefs(packs) {
 async function copyTools(projectRoot, { research }) {
   const destDir = join(projectRoot, '_lumina', 'tools');
   const coreTools = ['extract_pdf.py', 'fetch_pdf.py', 'id_utils.py'];
-  const researchTools = [
-    '_env.py', '_cache.py', 'discover.py', 'init_discovery.py', 'prepare_source.py',
-    'fetch_arxiv.py', 'fetch_wikipedia.py', 'fetch_s2.py', 'fetch_deepxiv.py',
-    'fetch_openalex.py', 'fetch_unpaywall.py', 'fetch_core.py', 'resolve_pdf.py',
-    'fetch_rss.py',
-  ];
-  const toolFiles = research ? [...coreTools, ...researchTools] : coreTools;
+  const toolFiles = research ? [...coreTools, ...RESEARCH_TOOL_FILES] : coreTools;
   // Parallelize: each copy is independent and destDir already exists.
   // Sequential awaits were the main Windows cold-start regression in v1.4
   // (~30 ms per file × 14 files dominates on NTFS + Defender).
@@ -1213,6 +1386,7 @@ async function seedWikiFiles(projectRoot) {
 
 async function createSkillSymlinks(projectRoot, skillRows, existingManifest, reLink, colors, t = null) {
   const strategies = {};
+  const errors = [];
 
   for (const skill of skillRows) {
     const target   = resolve(projectRoot, skill.relative_path);
@@ -1227,6 +1401,7 @@ async function createSkillSymlinks(projectRoot, skillRows, existingManifest, reL
         console.log(colors.yellow(`  [warn] ${result.message}`));
       }
     } catch (err) {
+      errors.push({ skill: skill.canonical_id, error: err });
       const msg = t
         ? t('error.symlink', { skill: skill.canonical_id, message: err.message })
         : `  [error] Failed to link ${skill.canonical_id}: ${err.message}`;
@@ -1234,7 +1409,7 @@ async function createSkillSymlinks(projectRoot, skillRows, existingManifest, reL
     }
   }
 
-  return { strategies };
+  return { strategies, errors };
 }
 
 async function buildFilesManifest(projectRoot, packs, pkgVersion) {

--- a/src/installer/commands.test.js
+++ b/src/installer/commands.test.js
@@ -9,7 +9,7 @@
 
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, writeFile, access, rm, mkdir } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile, access, rm, mkdir, readlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -17,7 +17,7 @@ import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
 import { installCommand, printPostUpgradeBanner, applyInstallOverrides, validateLanguageInput } from './commands.js';
-import { writeManifest, MANIFEST_SCHEMA_VERSION } from './manifest.js';
+import { readManifest, readSkillsManifest, writeManifest, MANIFEST_SCHEMA_VERSION } from './manifest.js';
 
 const require = createRequire(import.meta.url);
 const PKG = require('../../package.json');
@@ -381,6 +381,160 @@ describe('installCommand', () => {
 
       const after = await readFile(join(tmp, '_lumina', 'config', 'watchlist.yml'), 'utf8');
       assert.equal(after, customWatchlist);
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('CLI install from a nested directory upgrades the enclosing workspace', async () => {
+    const tmp = await makeTmpDir();
+    const nested = join(tmp, 'docs', 'notes');
+    try {
+      await installCommand({ cwd: tmp, yes: true, noUpdate: true });
+      await mkdir(nested, { recursive: true });
+
+      const result = spawnSync(
+        process.execPath,
+        [CLI, 'install', '--yes', '--no-update'],
+        { cwd: nested, encoding: 'utf8', timeout: 30000 },
+      );
+
+      assert.equal(result.status, 0, result.stderr);
+      await assert.rejects(() => access(join(nested, '_lumina', 'manifest.json')));
+      await access(join(tmp, '_lumina', 'manifest.json'));
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('upgrade removes obsolete managed skills, links, tools, and unchanged IDE stubs', async () => {
+    const tmp = await makeTmpDir();
+    try {
+      await installCommand({
+        cwd: tmp,
+        yes: true,
+        noUpdate: true,
+        packs: 'core,research',
+        ideTargets: 'claude_code,codex',
+      });
+      await access(join(tmp, 'wiki', 'topics'));
+
+      await installCommand({
+        cwd: tmp,
+        yes: true,
+        noUpdate: true,
+        packs: 'core',
+        ideTargets: 'codex',
+      });
+
+      await assert.rejects(() => access(join(tmp, '.agents', 'skills', 'lumi-research-discover')));
+      await assert.rejects(() => access(join(tmp, '.claude', 'skills', 'lumi-research-discover')));
+      await assert.rejects(() => access(join(tmp, '.claude', 'skills', 'lumi-init')));
+      await assert.rejects(() => access(join(tmp, '_lumina', 'tools', 'discover.py')));
+      await assert.rejects(() => access(join(tmp, '.env.example')));
+      await assert.rejects(() => access(join(tmp, 'CLAUDE.md')));
+      await access(join(tmp, 'AGENTS.md'));
+      await access(join(tmp, 'wiki', 'topics'));
+
+      const rows = await readSkillsManifest(tmp);
+      assert.ok(rows.every(row => row.pack === 'core'));
+      assert.ok(rows.every(row => row.target_link_path === ''));
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('upgrade preserves a modified stub when its IDE target is removed', async () => {
+    const tmp = await makeTmpDir();
+    try {
+      await installCommand({
+        cwd: tmp,
+        yes: true,
+        noUpdate: true,
+        ideTargets: 'claude_code,codex',
+      });
+      const custom = '# My Claude instructions\n';
+      await writeFile(join(tmp, 'CLAUDE.md'), custom, 'utf8');
+
+      await installCommand({
+        cwd: tmp,
+        yes: true,
+        noUpdate: true,
+        ideTargets: 'codex',
+      });
+
+      assert.equal(await readFile(join(tmp, 'CLAUDE.md'), 'utf8'), custom);
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('pack cleanup does not remove a user-created Claude path when Claude was never selected', async () => {
+    const tmp = await makeTmpDir();
+    const customPath = join(tmp, '.claude', 'skills', 'lumi-research-discover');
+    try {
+      await installCommand({
+        cwd: tmp,
+        yes: true,
+        noUpdate: true,
+        packs: 'core,research',
+        ideTargets: 'codex',
+      });
+      await mkdir(customPath, { recursive: true });
+      await writeFile(join(customPath, 'CUSTOM.md'), 'user-owned\n', 'utf8');
+
+      await installCommand({
+        cwd: tmp,
+        yes: true,
+        noUpdate: true,
+        packs: 'core',
+        ideTargets: 'codex',
+      });
+
+      assert.equal(
+        await readFile(join(customPath, 'CUSTOM.md'), 'utf8'),
+        'user-owned\n',
+      );
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('relocated workspace refreshes manifest paths and keeps portable skill links', async () => {
+    const tmp = await makeTmpDir();
+    const original = join(tmp, 'original');
+    const relocated = join(tmp, 'relocated');
+    try {
+      await mkdir(original, { recursive: true });
+      await installCommand({ cwd: original, yes: true, noUpdate: true });
+      const { cp } = await import('node:fs/promises');
+      await cp(original, relocated, { recursive: true });
+
+      await installCommand({ cwd: relocated, yes: true, noUpdate: true });
+
+      const manifest = await readManifest(relocated);
+      assert.equal(manifest.resolvedPaths.projectRoot, relocated);
+      if (process.platform !== 'win32') {
+        const target = await readlink(join(relocated, '.claude', 'skills', 'lumi-init'));
+        assert.equal(target, '../../.agents/skills/lumi-init');
+      }
+      await access(join(relocated, '.claude', 'skills', 'lumi-init', 'SKILL.md'));
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('install fails when required Claude skill links cannot be created', async () => {
+    const tmp = await makeTmpDir();
+    try {
+      await mkdir(join(tmp, '.claude'), { recursive: true });
+      await writeFile(join(tmp, '.claude', 'skills'), 'blocks skill directory', 'utf8');
+
+      await assert.rejects(
+        () => installCommand({ cwd: tmp, yes: true, noUpdate: true }),
+        (err) => err.code === 2 && /SKILL_LINKS_INCOMPLETE/.test(err.message),
+      );
+      await assert.rejects(() => access(join(tmp, '_lumina', 'manifest.json')));
     } finally {
       await cleanTmp(tmp);
     }

--- a/src/installer/commands.test.js
+++ b/src/installer/commands.test.js
@@ -573,6 +573,31 @@ describe("applyInstallOverrides — locale + language validation", () => {
     assert.equal(r.locale, "zh");
   });
 
+  test("interactive locale selection cascades installed default languages", () => {
+    const r = applyInstallOverrides({
+      ...base,
+      locale: "en",
+      selectedLocale: "vi",
+      communicationLang: "English",
+      documentOutputLang: "English",
+    }, {});
+    assert.equal(r.locale, "vi");
+    assert.equal(r.communicationLang, "Vietnamese");
+    assert.equal(r.documentOutputLang, "Vietnamese");
+    assert.equal("selectedLocale" in r, false);
+  });
+
+  test("--lang remains authoritative over an interactive locale selection", () => {
+    const r = applyInstallOverrides({
+      ...base,
+      locale: "en",
+      selectedLocale: "vi",
+      localeSwitchConfirmedFor: "vi",
+    }, { lang: "zh" });
+    assert.equal(r.locale, "zh");
+    assert.equal(r.localeSwitchConfirmedFor, "vi");
+  });
+
   test("--communication-language empty after trim throws code 2", () => {
     assert.throws(() => applyInstallOverrides({ ...base }, { communicationLang: "  " }), (err) => {
       assert.equal(err.code, 2);

--- a/src/installer/fs.js
+++ b/src/installer/fs.js
@@ -29,6 +29,7 @@ import {
   stat,
   readdir,
   symlink,
+  realpath,
   lstat,
   rm,
   copyFile,
@@ -186,6 +187,18 @@ export function fileHash(filePath) {
 // linkDirectory — symlink ladder
 // ---------------------------------------------------------------------------
 
+async function linkPointsToTarget(linkPath, target) {
+  try {
+    const [currentTarget, expectedTarget] = await Promise.all([
+      realpath(linkPath),
+      realpath(target),
+    ]);
+    return currentTarget === expectedTarget;
+  } catch (_) {
+    return false;
+  }
+}
+
 /**
  * @typedef {'symlink'|'junction'|'copy'} LinkStrategy
  */
@@ -206,9 +219,10 @@ export function fileHash(filePath) {
  *   2. fs.symlink(target, linkPath, 'junction')    — Windows directory junctions
  *   3. copyDir(target, linkPath) + warn            — final fallback
  *
- * When `linkPath` already exists and matches the same strategy recorded in
- * `existingStrategy` (from manifest), the function returns early (idempotent).
- * When `linkPath` already exists with a different strategy, it is removed first.
+ * When `linkPath` already exists and points to `target` with the same link
+ * strategy recorded in `existingStrategy`, the function returns early.
+ * Stale links are removed and recreated. Copy fallbacks are refreshed because
+ * their source target cannot be verified from filesystem metadata.
  *
  * @param {string}          target           - Real directory the link should point to.
  * @param {string}          linkPath         - Where the link/copy will be created.
@@ -220,20 +234,28 @@ export async function linkDirectory(target, linkPath, existingStrategy = null) {
   let existingStat = null;
   try {
     existingStat = await lstat(linkPath);
-  } catch (_) {
-    // Does not exist — proceed with creation
+  } catch (err) {
+    if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') throw err;
   }
 
   if (existingStat) {
     // If it is a symlink or junction pointing to the right target, keep it
-    if (existingStat.isSymbolicLink() && existingStrategy === 'symlink') {
-      return { strategy: 'symlink', message: `symlink already exists: ${linkPath}`, warning: false };
-    }
-    if (existingStat.isSymbolicLink() && existingStrategy === 'junction') {
-      return { strategy: 'junction', message: `junction already exists: ${linkPath}`, warning: false };
+    if (
+      existingStat.isSymbolicLink()
+      && (existingStrategy === 'symlink' || existingStrategy === 'junction')
+    ) {
+      if (await linkPointsToTarget(linkPath, target)) {
+        return {
+          strategy: existingStrategy,
+          message: `${existingStrategy} already exists: ${linkPath}`,
+          warning: false,
+        };
+      }
     }
     if (existingStat.isDirectory() && existingStrategy === 'copy') {
-      return { strategy: 'copy', message: `copy already exists: ${linkPath}`, warning: false };
+      await rm(linkPath, { recursive: true, force: true });
+      await copyDir(target, linkPath);
+      return { strategy: 'copy', message: `copy refreshed: ${linkPath}`, warning: false };
     }
     // Stale or mismatched — remove and recreate
     if (existingStat.isSymbolicLink()) {
@@ -249,8 +271,11 @@ export async function linkDirectory(target, linkPath, existingStrategy = null) {
 
   // Attempt 1: native symlink (macOS / Linux / Windows with Developer Mode)
   try {
-    await symlink(target, linkPath);
-    return { strategy: 'symlink', message: `symlink created: ${linkPath} -> ${target}`, warning: false };
+    const symlinkTarget = process.platform === 'win32'
+      ? resolve(target)
+      : (relative(dirname(linkPath), target) || '.');
+    await symlink(symlinkTarget, linkPath);
+    return { strategy: 'symlink', message: `symlink created: ${linkPath} -> ${symlinkTarget}`, warning: false };
   } catch (err1) {
     // EPERM on Windows without Developer Mode, or other platform restriction
     const isPermError = err1.code === 'EPERM' || err1.code === 'EACCES';
@@ -259,7 +284,7 @@ export async function linkDirectory(target, linkPath, existingStrategy = null) {
 
   // Attempt 2: Windows directory junction
   try {
-    await symlink(target, linkPath, 'junction');
+    await symlink(resolve(target), linkPath, 'junction');
     return { strategy: 'junction', message: `junction created: ${linkPath} -> ${target}`, warning: false };
   } catch (err2) {
     // Junction also failed — fall through to copy

--- a/src/installer/fs.test.js
+++ b/src/installer/fs.test.js
@@ -9,7 +9,7 @@
 
 import { test, describe, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, writeFile, mkdir, stat, lstat, unlink, rm, symlink, access } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile, mkdir, stat, lstat, unlink, rm, symlink, readlink, access } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve, sep } from 'node:path';
 import { constants as fsConstants } from 'node:fs';
@@ -295,6 +295,9 @@ describe('linkDirectory', () => {
     // The file must be accessible via linkPath regardless of strategy
     const content = await readFile(join(linkPath, 'skill.md'), 'utf8');
     assert.equal(content, 'content');
+    if (result.strategy === 'symlink' && process.platform !== 'win32') {
+      assert.equal(await readlink(linkPath), 'target-dir');
+    }
   });
 
   test('is idempotent — returns early if symlink already exists with same strategy', async () => {
@@ -309,6 +312,48 @@ describe('linkDirectory', () => {
     const r2 = await linkDirectory(target, linkPath, r1.strategy);
 
     assert.equal(r1.strategy, r2.strategy);
+  });
+
+  test('replaces a symlink that uses the recorded strategy but points to the wrong target', async (t) => {
+    const dir = await makeTmpDir();
+    const oldTarget = join(dir, 'old-project', '.agents', 'skills', 'lumi-test');
+    const currentTarget = join(dir, 'current-project', '.agents', 'skills', 'lumi-test');
+    const linkPath = join(dir, 'current-project', '.claude', 'skills', 'lumi-test');
+    await mkdir(oldTarget, { recursive: true });
+    await mkdir(currentTarget, { recursive: true });
+    await mkdir(resolve(linkPath, '..'), { recursive: true });
+    await writeFile(join(oldTarget, 'SKILL.md'), 'old project', 'utf8');
+    await writeFile(join(currentTarget, 'SKILL.md'), 'current project', 'utf8');
+
+    try {
+      await symlink(oldTarget, linkPath);
+    } catch (err) {
+      if (err.code === 'EPERM' || err.code === 'EACCES') {
+        t.skip('host does not permit directory symlinks');
+        return;
+      }
+      throw err;
+    }
+
+    const result = await linkDirectory(currentTarget, linkPath, 'symlink');
+
+    assert.equal(result.strategy, 'symlink');
+    assert.equal(await readFile(join(linkPath, 'SKILL.md'), 'utf8'), 'current project');
+  });
+
+  test('refreshes an existing copy fallback on reinstall', async () => {
+    const dir = await makeTmpDir();
+    const target = join(dir, 'target-dir');
+    const linkPath = join(dir, 'link-copy');
+    await mkdir(target, { recursive: true });
+    await mkdir(linkPath, { recursive: true });
+    await writeFile(join(target, 'SKILL.md'), 'current content', 'utf8');
+    await writeFile(join(linkPath, 'SKILL.md'), 'stale content', 'utf8');
+
+    const result = await linkDirectory(target, linkPath, 'copy');
+
+    assert.equal(result.strategy, 'copy');
+    assert.equal(await readFile(join(linkPath, 'SKILL.md'), 'utf8'), 'current content');
   });
 
   test('re-creates link when existing strategy does not match', async () => {

--- a/src/installer/locales/en.mjs
+++ b/src/installer/locales/en.mjs
@@ -75,6 +75,8 @@ export default {
   // ── Warnings ───────────────────────────────────────────────────────────────
   'warn.manifest_read':                        '[warn] Could not read existing manifest: {message}. Treating as fresh install.',
   'warn.copied_skills':                        '  [warn] Some skills were copied instead of symlinked. Run "lumina install --re-link" after enabling Windows Developer Mode.',
+  'warn.relocated':                            '  [warn] Workspace moved from {from} to {to}; managed links will be refreshed.',
+  'warn.preserved_modified_file':               '  [warn] Kept modified file that is no longer selected: {path}',
   'warn.upgrade_header':                       '[warn] Lumina upgraded v{from} -> v{to} — schema gap detected:',
   'warn.upgrade_errors':                       '       {errors} error(s), {warnings} warning(s) across legacy entries.',
   'warn.upgrade_fix_quick':                    '     Quick fix (deterministic):',

--- a/src/installer/locales/vi.mjs
+++ b/src/installer/locales/vi.mjs
@@ -74,6 +74,8 @@ export default {
   // ── Warnings ───────────────────────────────────────────────────────────────
   'warn.manifest_read':                        '[cảnh báo] Không đọc được manifest hiện tại: {message}. Coi như cài đặt mới.',
   'warn.copied_skills':                        '  [cảnh báo] Một số kỹ năng được sao chép thay vì symlink. Chạy "lumina install --re-link" sau khi bật Windows Developer Mode.',
+  'warn.relocated':                            '  [cảnh báo] Workspace đã chuyển từ {from} sang {to}; các liên kết do Lumina quản lý sẽ được làm mới.',
+  'warn.preserved_modified_file':               '  [cảnh báo] Giữ lại tệp đã được chỉnh sửa dù không còn được chọn: {path}',
   'warn.upgrade_header':                       '[cảnh báo] Lumina đã nâng cấp v{from} -> v{to} — phát hiện chênh lệch schema:',
   'warn.upgrade_errors':                       '       {errors} lỗi, {warnings} cảnh báo trên các mục cũ.',
   'warn.upgrade_fix_quick':                    '     Sửa nhanh (xác định):',

--- a/src/installer/locales/zh.mjs
+++ b/src/installer/locales/zh.mjs
@@ -80,6 +80,8 @@ export default {
   // ── Warnings ───────────────────────────────────────────────────────────────
   'warn.manifest_read':                        '[警告] 无法读取现有 manifest: {message}。视为全新安装。',
   'warn.copied_skills':                        '  [警告] 部分技能采用复制而非软链接。启用 Windows 开发者模式后请运行 "lumina install --re-link"。',
+  'warn.relocated':                            '  [警告] 工作区已从 {from} 移动到 {to}；Lumina 管理的链接将被刷新。',
+  'warn.preserved_modified_file':               '  [警告] 已保留不再选用但被修改过的文件：{path}',
   'warn.upgrade_header':                       '[警告] Lumina 已从 v{from} 升级到 v{to} — 检测到 schema 差异:',
   'warn.upgrade_errors':                       '       旧条目共有 {errors} 个错误、{warnings} 个警告。',
   'warn.upgrade_fix_quick':                    '     快速修复(确定性):',

--- a/src/installer/prompts.js
+++ b/src/installer/prompts.js
@@ -235,23 +235,24 @@ export async function runInstallPrompts({
   if (!existingManifest && resolveDestination) {
     const detected = await resolveDestination(directory);
     if (detected?.existingManifest && detected?.answers) {
-      let localeSwitchConfirmed = false;
-      if (detected.existingManifest.locale && detected.existingManifest.locale !== locale) {
+      const installedLocale = detected.existingManifest.locale ?? 'en';
+      let localeSwitchConfirmedFor = null;
+      if (installedLocale !== locale) {
         const proceed = await confirm({
-          message: `Locale change ${detected.existingManifest.locale} -> ${locale} will rewrite README.md and IDE stubs in the new locale. Outside-schema edits are preserved. Continue?`,
+          message: `Locale change ${installedLocale} -> ${locale} will rewrite README.md and IDE stubs in the new locale. Outside-schema edits are preserved. Continue?`,
           initialValue: false,
         });
         if (isCancel(proceed) || !proceed) {
           cancel(t ? t('prompt.cancelled') : 'Installation cancelled.');
           process.exit(4);
         }
-        localeSwitchConfirmed = true;
+        localeSwitchConfirmedFor = locale;
       }
       return {
         ...detected.answers,
         directory,
-        locale,
-        localeSwitchConfirmed,
+        selectedLocale: locale,
+        localeSwitchConfirmedFor,
       };
     }
   }

--- a/src/installer/prompts.js
+++ b/src/installer/prompts.js
@@ -149,9 +149,17 @@ export function buildPromptList(existingManifest, defaultLocale = 'en') {
  * @param {boolean} [opts.acceptDefaults=false] - Skip prompts; return defaults.
  * @param {string}  [opts.cwd]                  - Project root for defaults.
  * @param {Function} [opts.t]                   - Locale translator function.
+ * @param {Function} [opts.resolveDestination]  - Detect an existing install after directory selection.
  * @returns {Promise<InstallAnswers>}
  */
-export async function runInstallPrompts({ acceptDefaults = false, cwd = process.cwd(), existingManifest = null, defaultLocale = 'en', t: initialT = null } = {}) {
+export async function runInstallPrompts({
+  acceptDefaults = false,
+  cwd = process.cwd(),
+  existingManifest = null,
+  defaultLocale = 'en',
+  t: initialT = null,
+  resolveDestination = null,
+} = {}) {
   if (acceptDefaults) {
     const loc = existingManifest?.locale ?? defaultLocale;
     return defaultAnswers(cwd, loc);
@@ -223,6 +231,30 @@ export async function runInstallPrompts({ acceptDefaults = false, cwd = process.
   if (isCancel(directoryRaw)) { cancel(t ? t('prompt.cancelled') : 'Installation cancelled.'); process.exit(4); }
   const directory = expandUserPath(directoryRaw, cwdAbs);
   const projectName = defaultProjectName(directory);
+
+  if (!existingManifest && resolveDestination) {
+    const detected = await resolveDestination(directory);
+    if (detected?.existingManifest && detected?.answers) {
+      let localeSwitchConfirmed = false;
+      if (detected.existingManifest.locale && detected.existingManifest.locale !== locale) {
+        const proceed = await confirm({
+          message: `Locale change ${detected.existingManifest.locale} -> ${locale} will rewrite README.md and IDE stubs in the new locale. Outside-schema edits are preserved. Continue?`,
+          initialValue: false,
+        });
+        if (isCancel(proceed) || !proceed) {
+          cancel(t ? t('prompt.cancelled') : 'Installation cancelled.');
+          process.exit(4);
+        }
+        localeSwitchConfirmed = true;
+      }
+      return {
+        ...detected.answers,
+        directory,
+        locale,
+        localeSwitchConfirmed,
+      };
+    }
+  }
 
   // ── Prompt 2: Research purpose (multi-line free-form, optional) ─────────
   const researchPurposeRaw = await text({


### PR DESCRIPTION
## Summary

- detect and upgrade the enclosing Lumina workspace when `install` runs from a nested directory
- validate and repair stale skill links, using portable relative symlinks on POSIX
- reconcile removed packs and IDE targets while preserving modified or user-owned files
- fail clearly when required Claude skill links cannot be created
- document the upgraded behavior in English, Vietnamese, and Chinese

## Root cause

The installer reused existing links based only on the recorded strategy and did not verify their actual target. Upgrade cleanup also lacked enough previous-state reconciliation, leaving obsolete managed skills, links, tools, and generated stubs after pack or IDE changes.

## Validation

- `npm run test:installer` (161 passed, plus 38 command tests)
- `npm run test:scripts` (284 passed)
- `npm run test:python` (437 passed)
- `npm run ci:idempotency`
- `npm run ci:package`
- `npm run ci:cold-start`
- `git diff --check`

Closes #25