### PR TITLE
feat(wiki): support removing citation edges

### DIFF
--- a/src/scripts/wiki.mjs
+++ b/src/scripts/wiki.mjs
@@ -943,6 +943,36 @@ async function addCitation(projectRoot, fromSlug, toSlug) {
 }
 
 /**
+ * Remove a citation edge (cites) from wiki/graph/citations.jsonl.
+ * Idempotent.
+ * @param {string} projectRoot
+ * @param {string} fromSlug
+ * @param {string} toSlug
+ * @param {{dryRun?: boolean}} [opts]
+ * @returns {Promise<{removed: number, before: number, after?: number, dryRun?: boolean, matched?: object[]}>}
+ */
+async function removeCitation(projectRoot, fromSlug, toSlug, opts = {}) {
+  const graphDir = join(projectRoot, 'wiki', 'graph');
+  const citationsFile = join(graphDir, 'citations.jsonl');
+
+  const existing = await readJsonl(citationsFile);
+  const before = existing.length;
+
+  const matched = existing.filter(e => e.from === fromSlug && e.to === toSlug);
+  const remaining = existing.filter(e => !(e.from === fromSlug && e.to === toSlug));
+
+  if (opts.dryRun) {
+    return { dryRun: true, removed: matched.length, before, matched };
+  }
+
+  if (matched.length > 0) {
+    await writeJsonl(citationsFile, remaining);
+  }
+
+  return { removed: matched.length, before, after: remaining.length };
+}
+
+/**
  * Batch-add edges from a JSON file.
  * Reads [{from, type, to, confidence?}, ...], validates all, then writes in one pass.
  * @param {string} projectRoot
@@ -1782,6 +1812,7 @@ async function main(argv) {
       '  set-meta <slug> <key> <value> [--json-value]  Set frontmatter key',
       '  add-edge <from> <type> <to> [--confidence high|medium|low]',
       '  add-citation <from> <to>        Append cites edge to citations.jsonl',
+      '  remove-citation <from> <to> [--dry-run]  Remove cites edge from citations.jsonl',
       '  batch-edges <json-file>         Apply array of edges from JSON file',
       '  dedup-edges                     Deduplicate edges.jsonl',
       '  remove-edge <from> <type> <to> [--dry-run]',
@@ -1958,6 +1989,27 @@ async function main(argv) {
       }
 
       // -----------------------------------------------------------------------
+      case 'remove-citation': {
+        const fromSlug = positional[0];
+        const toSlug = positional[1];
+
+        if (!fromSlug || !toSlug) {
+          emitError('remove-citation requires <from-slug> <to-slug>', 2);
+          process.exit(2);
+        }
+        if (fromSlug.includes('..') || toSlug.includes('..')) {
+          emitError('Slug may not contain ..', 2);
+          process.exit(2);
+        }
+
+        const projectRoot = await requireProjectRoot();
+        const dryRun = Boolean(flags['dry-run']);
+        const result = await removeCitation(projectRoot, fromSlug, toSlug, { dryRun });
+        emitJson(result);
+        break;
+      }
+
+      // -----------------------------------------------------------------------
       case 'batch-edges': {
         const jsonFile = positional[0];
         if (!jsonFile) {
@@ -1992,7 +2044,7 @@ async function main(argv) {
 
         if (edgeType === 'cites' || edgeType === 'cited_by') {
           emitError(
-            'Citations live in wiki/graph/citations.jsonl, not edges.jsonl; remove-citation is not yet available.',
+            'Citations live in wiki/graph/citations.jsonl, not edges.jsonl; use `remove-citation <citing> <cited>` (for a cited_by relation, the citing source is the <cited> argument).',
             2,
           );
           process.exit(2);
@@ -2033,7 +2085,7 @@ async function main(argv) {
 
         if ([oldType, newType].includes('cites') || [oldType, newType].includes('cited_by')) {
           emitError(
-            'Citations live in wiki/graph/citations.jsonl, not edges.jsonl; replace-edge cannot retype cites/cited_by edges.',
+            'Citations live in wiki/graph/citations.jsonl, not edges.jsonl; replace-edge cannot retype cites/cited_by edges. Use add-citation / remove-citation to manage citations.',
             2,
           );
           process.exit(2);

--- a/src/scripts/wiki.test.mjs
+++ b/src/scripts/wiki.test.mjs
@@ -819,6 +819,117 @@ describe('add-citation', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: remove-citation
+// ---------------------------------------------------------------------------
+
+describe('remove-citation', () => {
+  test('removes a citation from citations.jsonl', async () => {
+    const tmp = await makeTmp();
+    try {
+      initWorkspace(tmp);
+      runWiki(['add-citation', 'src-a', 'src-b'], { cwd: tmp });
+      runWiki(['add-citation', 'src-a', 'src-c'], { cwd: tmp });
+
+      const r = runWiki(['remove-citation', 'src-a', 'src-b'], { cwd: tmp });
+      assert.equal(r.status, 0, `remove-citation failed: ${r.stderr}`);
+      const json = parseJson(r.stdout);
+      assert.equal(json.removed, 1);
+
+      const content = await readFile(join(tmp, 'wiki', 'graph', 'citations.jsonl'), 'utf8');
+      const citations = content.trim().split('\n').map(l => JSON.parse(l));
+      assert.ok(!citations.some(e => e.from === 'src-a' && e.to === 'src-b'), 'src-a -> src-b should be gone');
+      assert.ok(citations.some(e => e.from === 'src-a' && e.to === 'src-c'), 'src-a -> src-c should remain');
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('--dry-run does not modify citations.jsonl', async () => {
+    const tmp = await makeTmp();
+    try {
+      initWorkspace(tmp);
+      runWiki(['add-citation', 'src-a', 'src-b'], { cwd: tmp });
+      const citationsFile = join(tmp, 'wiki', 'graph', 'citations.jsonl');
+      const hashBefore = await hashFile(citationsFile);
+
+      const r = runWiki(['remove-citation', 'src-a', 'src-b', '--dry-run'], { cwd: tmp });
+      assert.equal(r.status, 0, `remove-citation --dry-run failed: ${r.stderr}`);
+      const json = parseJson(r.stdout);
+      assert.equal(json.dryRun, true);
+      assert.equal(json.removed, 1);
+      assert.equal(json.matched.length, 1);
+
+      const hashAfter = await hashFile(citationsFile);
+      assert.equal(hashBefore, hashAfter, 'citations.jsonl unchanged by dry-run');
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('is idempotent when the citation is absent', async () => {
+    const tmp = await makeTmp();
+    try {
+      initWorkspace(tmp);
+      runWiki(['add-citation', 'src-a', 'src-b'], { cwd: tmp });
+      const citationsFile = join(tmp, 'wiki', 'graph', 'citations.jsonl');
+      const hashBefore = await hashFile(citationsFile);
+
+      const r = runWiki(['remove-citation', 'src-x', 'src-y'], { cwd: tmp });
+      assert.equal(r.status, 0, `remove-citation failed: ${r.stderr}`);
+      const json = parseJson(r.stdout);
+      assert.equal(json.removed, 0);
+
+      const hashAfter = await hashFile(citationsFile);
+      assert.equal(hashBefore, hashAfter, 'citations.jsonl unchanged when citation absent');
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('is safe to run twice', async () => {
+    const tmp = await makeTmp();
+    try {
+      initWorkspace(tmp);
+      runWiki(['add-citation', 'src-a', 'src-b'], { cwd: tmp });
+
+      const r1 = runWiki(['remove-citation', 'src-a', 'src-b'], { cwd: tmp });
+      assert.equal(r1.status, 0, `remove-citation (1st) failed: ${r1.stderr}`);
+      const json1 = parseJson(r1.stdout);
+      assert.equal(json1.removed, 1);
+
+      const r2 = runWiki(['remove-citation', 'src-a', 'src-b'], { cwd: tmp });
+      assert.equal(r2.status, 0, `remove-citation (2nd) failed: ${r2.stderr}`);
+      const json2 = parseJson(r2.stdout);
+      assert.equal(json2.removed, 0);
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('rejects missing arguments', async () => {
+    const tmp = await makeTmp();
+    try {
+      initWorkspace(tmp);
+      const r = runWiki(['remove-citation', 'src-a'], { cwd: tmp });
+      assert.equal(r.status, 2);
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('rejects slugs containing ..', async () => {
+    const tmp = await makeTmp();
+    try {
+      initWorkspace(tmp);
+      const r = runWiki(['remove-citation', '../evil', 'src-b'], { cwd: tmp });
+      assert.equal(r.status, 2);
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: batch-edges
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds an idempotent `remove-citation <from> <to> [--dry-run]` command to `src/scripts/wiki.mjs`, mirroring the existing `add-citation` API. Citation edges live in `wiki/graph/citations.jsonl` (separate from `edges.jsonl`), and until now there was no supported way to remove one — verification workflows had no way to correct a false citation without hand-editing derived graph state, which the wiki rules prohibit.

Implements the issue's preferred **Option A** (a dedicated command over overloading `remove-edge`).

## Changes

**`src/scripts/wiki.mjs`**
- **`removeCitation` helper** — reads `citations.jsonl` via `readJsonl`, filters out the matching forward `{from, cites, to}` record, writes back via `writeJsonl` (same `atomicWrite` guarantees as existing graph mutations). Citations store no reverse record (`cited_by` is derived at read time in `readCitationsForSlug`), so only the single forward record is removed.
- **`case 'remove-citation'`** — `..` slug guard, `--dry-run` support, `emitJson` output; same conventions as `add-citation` / `remove-edge`.
- **Reworded guards** — the `remove-edge` guard now names `remove-citation` and clarifies the reversed direction for `cited_by`; `replace-edge` references both `add-citation` and `remove-citation`. (Previously said "remove-citation is not yet available".)
- **Help/usage line** for the new command.

**`src/scripts/wiki.test.mjs`**
- New `describe('remove-citation')` block, styled after the existing `add-citation` / `remove-edge` tests (shell out via `runWiki`, temp workspace via `makeTmp`/`initWorkspace`, hash-based unchanged assertions via `hashFile`).

## Acceptance criteria

- [x] Removes one selected citation without touching unrelated records (test: removing a→b leaves a→c intact).
- [x] Supports `--dry-run` (test: `hashFile` identical before/after, `dryRun:true`).
- [x] Idempotent / safe when the citation is absent (`removed:0`, exit 0) and safe to run twice.
- [x] Uses the same atomic-write guarantees as existing graph mutations (`writeJsonl` → `atomicWrite`).
- [x] Listed in `wiki.mjs` help.
- [x] Covered by tests — 6 new `node:test` cases; `remove-edge`'s existing "rejects cites" test still passes.

## Test results

- `node --test src/scripts/wiki.test.mjs` → **121 pass, 0 fail**
- `npm run test:scripts` (full scripts suite) → **326 pass, 0 fail**

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)