### PR TITLE
ci(publish): auto-create GitHub Release from CHANGELOG on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 concurrency:
@@ -50,3 +50,25 @@ jobs:
 
       - name: Publish package
         run: npm publish
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          notes="$(awk -v prefix="## [${version}]" '
+            index($0, prefix) == 1 { flag = 1; next }
+            /^## \[/ && flag { exit }
+            flag { print }
+          ' CHANGELOG.md)"
+          notes="$(printf '%s\n' "$notes" | sed -e '/./,$!d')"
+          if [ -n "$notes" ]; then
+            printf '%s\n' "$notes" > release-notes.md
+            gh release create "${GITHUB_REF_NAME}" --verify-tag \
+              --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
+          else
+            echo "No CHANGELOG entry for ${version}; falling back to generated notes."
+            gh release create "${GITHUB_REF_NAME}" --verify-tag \
+              --title "${GITHUB_REF_NAME}" --generate-notes
+          fi


### PR DESCRIPTION
## What

Adds a final step to the `Publish npm` workflow that, after a successful `npm publish`, creates a GitHub Release for the pushed tag. Release notes are the matching `## [X.Y.Z]` section extracted from `CHANGELOG.md`; if that version has no changelog section, it falls back to `--generate-notes`. `gh` auto-determines the *Latest* badge by semver.

Also raises the workflow `permissions.contents` from `read` to `write` (required to create releases).

## Why

`publish.yml` only ran `npm publish` on a `v*` tag, so GitHub Releases were created by hand. v1.9.0–v1.9.2 shipped to npm but had no GitHub Release (the *Latest* badge was stuck on v1.8.0). This closes that gap for all future tag pushes.

## Verification

- `publish.yml` passes YAML validation.
- The awk/sed extraction was run against the real `CHANGELOG.md` for 1.9.2 / 1.9.0 / 1.8.0 and returns each version's exact section without bleeding into the next.
- Runtime publish behavior is unchanged up to and including `npm publish`; the release step only runs after a successful publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)