### PR TITLE
ci(publish): publish pre-release tags to their own npm dist-tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,10 +31,31 @@ jobs:
           package-manager-cache: false
 
       - name: Verify tag matches package version
+        id: channel
         shell: bash
         run: |
           version="$(node -p "require('./package.json').version")"
           test "${GITHUB_REF_NAME}" = "v${version}"
+
+          # The npm dist-tag comes from the version's pre-release identifier:
+          #   1.12.0        -> latest   (the default channel every user gets)
+          #   1.12.0-next.0 -> next     (npx lumina-wiki@next)
+          #   1.12.0-rc.1   -> rc
+          # A pre-release publish must never move `latest`, so an identifier we
+          # cannot read is a hard stop rather than a silent fallback.
+          if [[ "$version" == *-* ]]; then
+            channel="${version#*-}"
+            channel="${channel%%.*}"
+            if [[ ! "$channel" =~ ^[a-z][a-z0-9-]*$ ]] || [ "$channel" = "latest" ]; then
+              echo "Refusing to publish ${version}: unusable pre-release channel '${channel}'." >&2
+              exit 1
+            fi
+            echo "npm_tag=${channel}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Install Node dependencies
         run: npm ci
@@ -49,14 +70,19 @@ jobs:
         run: npm run ci:package
 
       - name: Publish package
-        run: npm publish
+        run: npm publish --tag "${{ steps.channel.outputs.npm_tag }}"
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          PRERELEASE: ${{ steps.channel.outputs.prerelease }}
         shell: bash
         run: |
           version="${GITHUB_REF_NAME#v}"
+          flags=(--verify-tag --title "${GITHUB_REF_NAME}")
+          if [ "$PRERELEASE" = "true" ]; then
+            flags+=(--prerelease)
+          fi
           notes="$(awk -v prefix="## [${version}]" '
             index($0, prefix) == 1 { flag = 1; next }
             /^## \[/ && flag { exit }
@@ -65,10 +91,8 @@ jobs:
           notes="$(printf '%s\n' "$notes" | sed -e '/./,$!d')"
           if [ -n "$notes" ]; then
             printf '%s\n' "$notes" > release-notes.md
-            gh release create "${GITHUB_REF_NAME}" --verify-tag \
-              --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
+            gh release create "${GITHUB_REF_NAME}" "${flags[@]}" --notes-file release-notes.md
           else
             echo "No CHANGELOG entry for ${version}; falling back to generated notes."
-            gh release create "${GITHUB_REF_NAME}" --verify-tag \
-              --title "${GITHUB_REF_NAME}" --generate-notes
+            gh release create "${GITHUB_REF_NAME}" "${flags[@]}" --generate-notes
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,10 +43,20 @@ jobs:
           #   1.12.0-rc.1   -> rc
           # A pre-release publish must never move `latest`, so an identifier we
           # cannot read is a hard stop rather than a silent fallback.
-          if [[ "$version" == *-* ]]; then
-            channel="${version#*-}"
+          #
+          # Build metadata is stripped first: it is not part of the pre-release,
+          # yet it may itself contain a hyphen (1.2.3+build-next is a *stable*
+          # release) or trail one (1.2.3-next+build).
+          precedence="${version%%+*}"
+          if [[ "$precedence" == *-* ]]; then
+            channel="${precedence#*-}"
             channel="${channel%%.*}"
-            if [[ ! "$channel" =~ ^[a-z][a-z0-9-]*$ ]] || [ "$channel" = "latest" ]; then
+            # npm refuses any dist-tag that parses as a SemVer range, so "x" and
+            # "v1" are caught here rather than after the gates have run.
+            if [[ ! "$channel" =~ ^[a-z][a-z0-9-]*$ ]] \
+              || [ "$channel" = "latest" ] \
+              || [ "$channel" = "x" ] \
+              || [[ "$channel" =~ ^v[0-9]+$ ]]; then
               echo "Refusing to publish ${version}: unusable pre-release channel '${channel}'." >&2
               exit 1
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to Lumina-Wiki are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- Pre-release publishing channel. A tag whose version carries a pre-release
+  identifier (`v1.12.0-next.0`, `v1.12.0-rc.1`) now publishes to an npm
+  dist-tag of that name instead of `latest`, so a build can be handed to
+  testers with `npx lumina-wiki@next install` without touching what everyone
+  else installs. The channel is derived from the version alone — an
+  identifier that cannot be read as one fails the publish rather than
+  guessing — and such releases are marked as pre-releases on GitHub.
+  Documented in `docs/DEVELOPMENT.md` §6.
+
+### Fixed
+
+- The update check compared versions by their numeric core only, so anyone
+  running a pre-release build was never told about the stable release it led
+  to: `1.12.0-next.0` and `1.12.0` looked identical to it. Version comparison
+  now follows semver precedence — stable outranks its own pre-releases,
+  numeric identifiers compare numerically, and build metadata is ignored.
+
 ## [1.11.0] - 2026-07-27
 
 ### Fixed
@@ -1018,7 +1039,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-[Unreleased]: https://github.com/tronghieu/lumina-wiki/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/tronghieu/lumina-wiki/compare/v1.11.0...HEAD
 [1.5.0]: https://github.com/tronghieu/lumina-wiki/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/tronghieu/lumina-wiki/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/tronghieu/lumina-wiki/compare/v1.2.0...v1.3.0

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -140,7 +140,7 @@ The npm dist-tag is derived from the version itself — the workflow never takes
 | `1.12.0-next.0` | `v1.12.0-next.0` | `next` | pre-release |
 | `1.12.0-rc.1` | `v1.12.0-rc.1` | `rc` | pre-release |
 
-A version with a pre-release identifier publishes to a channel of that name and **leaves `latest` untouched**, so nobody running `npx lumina-wiki install` is affected. An identifier the workflow cannot read as a channel — empty, uppercase, purely numeric, or literally `latest` — fails the job rather than guessing.
+A version with a pre-release identifier publishes to a channel of that name and **leaves `latest` untouched**, so nobody running `npx lumina-wiki install` is affected. Build metadata is not part of the channel (`1.12.0+build-next` is a stable release, not a `next` one). An identifier the workflow cannot read as a channel — empty, uppercase, purely numeric, literally `latest`, or one npm itself refuses because it parses as a version range (`x`, `v1`) — fails the job rather than guessing.
 
 ### Cutting a pre-release
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -128,6 +128,48 @@ npm run test:update        # update-check timeouts
 
 ---
 
+## 6. Releasing — `latest` and pre-release channels
+
+Publishing is tag-driven: pushing a `v*` tag runs `.github/workflows/publish.yml`, which re-runs the gates against the tagged commit, publishes to npm, and opens a GitHub Release from the matching `CHANGELOG.md` entry.
+
+The npm dist-tag is derived from the version itself — the workflow never takes it as an input:
+
+| `package.json` version | git tag | npm dist-tag | GitHub Release |
+|---|---|---|---|
+| `1.12.0` | `v1.12.0` | `latest` | normal |
+| `1.12.0-next.0` | `v1.12.0-next.0` | `next` | pre-release |
+| `1.12.0-rc.1` | `v1.12.0-rc.1` | `rc` | pre-release |
+
+A version with a pre-release identifier publishes to a channel of that name and **leaves `latest` untouched**, so nobody running `npx lumina-wiki install` is affected. An identifier the workflow cannot read as a channel — empty, uppercase, purely numeric, or literally `latest` — fails the job rather than guessing.
+
+### Cutting a pre-release
+
+```bash
+# 1.12.0-next.0, .next.1, … as many as the change needs
+npm version 1.12.0-next.0 --no-git-tag-version
+git commit -am "chore(release): 1.12.0-next.0"
+git tag v1.12.0-next.0
+git push origin main --tags
+```
+
+Testers then run:
+
+```bash
+npx lumina-wiki@next install
+```
+
+When the change is ready, bump to the plain `1.12.0`, tag it, and the same workflow moves `latest`.
+
+### What pre-release users see
+
+`checkForUpdate()` always queries the `latest` dist-tag, and `isNewerVersion()` follows semver precedence — a stable release outranks the pre-release that led to it. So someone on `1.12.0-next.0` is nudged to upgrade the moment `1.12.0` ships, but is not nagged while only pre-releases exist. They are *not* notified about a newer build within the same channel; re-running `npx lumina-wiki@next install` is the way to pick that up.
+
+### Before tagging anything
+
+Prefer `npm pack` (cycle 3 above) over a pre-release for a change you can verify yourself. A pre-release is for putting a build in *someone else's* hands; the tarball is faster and leaves no published artifact behind.
+
+---
+
 ## Testing AI-agent global installs (`--agents`)
 
 `--agents openclaw` / `--agents hermes` write skills into a **global**, user-level skills directory (see `docs/specs/spec-librarian-mode/platform-integration.md` for the exact paths per platform), not into a project. That means a careless manual test can drop files into your real home directory.

--- a/src/installer/update-check.js
+++ b/src/installer/update-check.js
@@ -60,24 +60,78 @@ export async function checkForUpdate(currentVersion) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Split a version string into its numeric core and pre-release identifiers.
+ * Tolerates a leading "v", partial versions ("2", "1.1"), and build metadata.
+ *
+ * @param {string} version - e.g. "1.12.0", "v1.12.0-next.0", "1.12.0+build.5".
+ * @returns {{core: number[], pre: string[]}}
+ */
+function parseVersion(version) {
+  const cleaned = String(version)
+    .trim()
+    .replace(/^v/, '')
+    .split('+')[0]; // build metadata is never part of precedence
+
+  const dash = cleaned.indexOf('-');
+  const coreText = dash === -1 ? cleaned : cleaned.slice(0, dash);
+  const preText = dash === -1 ? '' : cleaned.slice(dash + 1);
+
+  const parts = coreText.split('.').map(Number);
+  return {
+    core: [parts[0] || 0, parts[1] || 0, parts[2] || 0],
+    pre: preText ? preText.split('.') : [],
+  };
+}
+
+/**
+ * Compare pre-release identifier lists by semver precedence rules:
+ * a stable release outranks any pre-release of the same core version,
+ * numeric identifiers compare numerically and rank below alphanumeric ones,
+ * and a longer identifier list wins when every shared field is equal.
+ *
+ * @param {string[]} a - Candidate identifiers ([] when stable).
+ * @param {string[]} b - Baseline identifiers ([] when stable).
+ * @returns {number} 1 if `a` is higher, -1 if lower, 0 if equal.
+ */
+function comparePrerelease(a, b) {
+  if (a.length === 0 && b.length === 0) return 0;
+  if (a.length === 0) return 1;
+  if (b.length === 0) return -1;
+
+  for (let i = 0; i < Math.max(a.length, b.length); i += 1) {
+    if (i >= a.length) return -1;
+    if (i >= b.length) return 1;
+
+    const aPart = a[i];
+    const bPart = b[i];
+    if (aPart === bPart) continue;
+
+    const aNumeric = /^\d+$/.test(aPart);
+    const bNumeric = /^\d+$/.test(bPart);
+    if (aNumeric && bNumeric) return Number(aPart) > Number(bPart) ? 1 : -1;
+    if (aNumeric !== bNumeric) return aNumeric ? -1 : 1;
+    return aPart > bPart ? 1 : -1;
+  }
+  return 0;
+}
+
+/**
  * Compare two semver version strings.
  * Returns true if `candidate` is strictly newer than `baseline`.
- * Handles simple MAJOR.MINOR.PATCH format without pre-release suffixes.
+ * Handles MAJOR.MINOR.PATCH plus pre-release suffixes, so someone running
+ * a pre-release build (1.12.0-next.0) is still told about the stable
+ * release it leads to (1.12.0).
  *
  * @param {string} candidate - Version to test.
  * @param {string} baseline  - Current version.
  * @returns {boolean}
  */
 export function isNewerVersion(candidate, baseline) {
-  const parseParts = (v) => {
-    const parts = String(v).replace(/^v/, '').split('.').map(Number);
-    return [parts[0] || 0, parts[1] || 0, parts[2] || 0];
-  };
+  const c = parseVersion(candidate);
+  const b = parseVersion(baseline);
 
-  const [cMajor, cMinor, cPatch] = parseParts(candidate);
-  const [bMajor, bMinor, bPatch] = parseParts(baseline);
-
-  if (cMajor !== bMajor) return cMajor > bMajor;
-  if (cMinor !== bMinor) return cMinor > bMinor;
-  return cPatch > bPatch;
+  for (let i = 0; i < 3; i += 1) {
+    if (c.core[i] !== b.core[i]) return c.core[i] > b.core[i];
+  }
+  return comparePrerelease(c.pre, b.pre) > 0;
 }

--- a/src/installer/update-check.test.js
+++ b/src/installer/update-check.test.js
@@ -49,6 +49,55 @@ describe('isNewerVersion', () => {
 });
 
 // ---------------------------------------------------------------------------
+// isNewerVersion — pre-release channels (npx lumina-wiki@next)
+// ---------------------------------------------------------------------------
+
+describe('isNewerVersion — pre-release', () => {
+  test('stable outranks the pre-release of the same version', () => {
+    assert.equal(isNewerVersion('1.12.0', '1.12.0-next.0'), true);
+  });
+
+  test('pre-release does not outrank its own stable release', () => {
+    assert.equal(isNewerVersion('1.12.0-next.0', '1.12.0'), false);
+  });
+
+  test('pre-release of a future version outranks current stable', () => {
+    assert.equal(isNewerVersion('1.12.0-next.0', '1.11.0'), true);
+  });
+
+  test('older stable does not outrank a newer pre-release', () => {
+    assert.equal(isNewerVersion('1.11.0', '1.12.0-next.0'), false);
+  });
+
+  test('later build within the same channel is newer', () => {
+    assert.equal(isNewerVersion('1.12.0-next.1', '1.12.0-next.0'), true);
+    assert.equal(isNewerVersion('1.12.0-next.0', '1.12.0-next.1'), false);
+  });
+
+  test('numeric identifiers compare numerically, not as strings', () => {
+    assert.equal(isNewerVersion('1.12.0-next.10', '1.12.0-next.9'), true);
+  });
+
+  test('identical pre-releases are not newer', () => {
+    assert.equal(isNewerVersion('1.12.0-next.0', '1.12.0-next.0'), false);
+  });
+
+  test('alphanumeric identifiers rank above numeric ones', () => {
+    assert.equal(isNewerVersion('1.12.0-rc.1', '1.12.0-beta.1'), true);
+    assert.equal(isNewerVersion('1.12.0-alpha.1', '1.12.0-beta.1'), false);
+  });
+
+  test('a longer identifier list wins when shared fields are equal', () => {
+    assert.equal(isNewerVersion('1.12.0-next.0.1', '1.12.0-next.0'), true);
+  });
+
+  test('build metadata is ignored for precedence', () => {
+    assert.equal(isNewerVersion('1.12.0+build.9', '1.12.0'), false);
+    assert.equal(isNewerVersion('1.12.1+build.1', '1.12.0'), true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // checkForUpdate — environment variable suppression
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Pushing a tag whose version carries a pre-release identifier (`v1.12.0-next.0`, `v1.12.0-rc.1`) now publishes to an npm dist-tag of that name instead of `latest`, so an unreleased build can be handed to testers with `npx lumina-wiki@next install` without moving what everyone else gets from plain `npx lumina-wiki install`. Stable tags behave exactly as before.

Shipping that channel exposed a real bug in the update check, fixed here too: it compared versions by numeric core only, so `1.12.0-next.0` and `1.12.0` looked identical to it and anyone on a pre-release build would never be told about the stable release their build led to.

## Type of change

- [x] Other (release tooling — `.github/workflows/publish.yml`)
- [x] Bug fix (`isNewerVersion()` pre-release precedence)
- [x] Docs only (`docs/DEVELOPMENT.md` §6)

## What changed

**`.github/workflows/publish.yml`**

The existing "Verify tag matches package version" step now also derives the publish channel from the version, and exports it to the publish and release steps:

| `package.json` version | npm dist-tag | GitHub Release |
|---|---|---|
| `1.12.0` | `latest` | normal |
| `1.12.0-next.0` | `next` | pre-release |
| `1.12.0-rc.1` | `rc` | pre-release |

The channel is derived from the version alone — never taken as a workflow input — and an identifier that cannot be read as a channel (empty, uppercase, purely numeric, or literally `latest`) fails the job rather than guessing, since the cost of guessing wrong is moving `latest` to a pre-release. `npm publish` is now `npm publish --tag <channel>`; a stable release passes `--tag latest` explicitly, which is what the bare command already did.

**`src/installer/update-check.js`**

`isNewerVersion()` now follows semver precedence: core triple first, then pre-release identifiers — stable outranks its own pre-releases, numeric identifiers compare numerically and rank below alphanumeric ones, a longer identifier list wins when shared fields are equal, and build metadata is ignored. Partial versions (`"2"`, `"1.1"`) still parse as before. `checkForUpdate()` is unchanged and still queries only the `latest` dist-tag, so a pre-release user is nudged to stable the moment it ships and is not nagged in between; they are not notified about newer builds within their own channel, which is documented rather than fixed.

**`docs/DEVELOPMENT.md`** — new §6 covering the version→channel table, how to cut a pre-release, what pre-release users see, and a note preferring `npm pack` over a pre-release for anything you can verify yourself.

## Trilingual docs

- [x] N/A — no user-facing surface changed

`docs/DEVELOPMENT.md` is contributor-facing (CONTRIBUTING §6 scopes the trilingual requirement to user-facing surfaces). Advertising `npx lumina-wiki@next` in `README.md` / `README.vi.md` / `README.zh.md` is worth a follow-up once the first `next` build actually exists — pointing users at an empty dist-tag would just produce `No matching version`.

## Tests

- [x] `npm run test:installer` — 283 pass, 2 skipped, 0 fail (includes 11 new `isNewerVersion` pre-release cases)
- [x] `npm run test:scripts` — 468 pass
- [x] `npm run test:catalog` — 11 pass
- [x] `npm run ci:idempotency` — all 5 scenarios clean
- [x] `npm run ci:package` — 113 files
- [ ] `npm run test:python` — not run; pytest is unavailable in this container. No Python file is touched by this change.

The channel-derivation shell logic was also exercised directly against `1.12.0`, `1.12.0-next.0`, `1.12.0-next`, `1.12.0-beta.3`, `1.12.0-rc.1`, `2.0.0-next.10`, `1.12.0-latest.0`, `1.12.0-.0`, `1.12.0-NEXT.0` and `1.12.0-0` — the last four correctly refuse to publish.

## Rule deviations

None.

## Related issues / PRs

Follows up on the release tooling added in #33.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbavAY3VB8NQYS1fuzzkEB)_