### PR TITLE
chore(release): 1.12.0, signed with npm provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,7 +80,10 @@ jobs:
         run: npm run ci:package
 
       - name: Publish package
-        run: npm publish --tag "${{ steps.channel.outputs.npm_tag }}"
+        # --provenance signs the tarball with the workflow's OIDC identity, so
+        # npm can attest which repo, commit and run built it. Requires the
+        # id-token: write permission granted above.
+        run: npm publish --provenance --tag "${{ steps.channel.outputs.npm_tag }}"
 
       - name: Create GitHub Release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [1.12.0] - 2026-08-12
 
-> 1.11.0 was prepared in the changelog but never tagged, so it never reached
-> npm — the last published version was 1.10.1. Its fixes ship here.
+> This release also carries everything prepared for 1.11.0 on 2026-07-27:
+> that version was bumped and documented but never tagged, so it never
+> reached npm. The last published version was 1.10.1.
 
 ### Added
 
@@ -20,11 +21,56 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   identifier that cannot be read as one fails the publish rather than
   guessing — and such releases are marked as pre-releases on GitHub.
   Documented in `docs/DEVELOPMENT.md` §6.
-- Published packages now carry npm provenance. Every publish is signed with
-  the release workflow's OIDC identity, so npm can attest which repository,
-  commit and workflow run produced the tarball, and anyone can verify it
-  with `npm audit signatures`. A stolen npm token can no longer be used to
-  ship a package that looks like it came from this repository.
+- Published packages now carry npm provenance. Every publish from the
+  release workflow is signed with its OIDC identity, so npm records which
+  repository, commit and workflow run produced the tarball; `npm audit
+  signatures` verifies it and npmjs.com links back to the build. This does
+  not block a publish made with a stolen token — npm still accepts an
+  unsigned one — but such a package arrives with no attestation at all,
+  and that absence is visible to anyone who looks.
+- The six page templates above now match the wiki's frontmatter rules
+  exactly, and a new automated test compares every template against the
+  schema so they can't silently drift out of sync again.
+- `lint.mjs --fix` recovers more on its own now: an empty list for
+  list-type fields, a date recovered from an older field name or the
+  file's own save timestamp, a page's `id` recovered from an older field
+  name or its file path, its `type` from the folder it lives in, and its
+  title from the page's own heading. Where no safe value exists — a
+  publication year, an importance rating — it leaves the field reported as
+  missing instead of guessing, so a wrong value never quietly passes as
+  fixed.
+- `lint.mjs --fix` gained two further repairs: it corrects fields holding
+  the wrong kind of value (including rebuilding a page's source list and
+  related-concepts list straight from the link graph, which already held
+  the real answer), and it fixes wiki links that are missing their folder
+  name whenever exactly one page could be the intended target — never when
+  more than one page could match.
+- `lint.mjs --suggest` now actually does something. It had been accepted as
+  a flag since it shipped but silently did nothing; it now lists a concrete
+  next step for every finding the automatic repair could not resolve on its
+  own.
+- `lint.mjs --fix` now clears out an old field name once its replacement is
+  confirmed to hold the same information — for example, once a page's `id`
+  is in place, a leftover, older `slug` field carrying the identical value
+  is removed instead of being reported forever. "Matches" now also covers
+  the most common near-miss found in real wikis: an `id` that names both
+  its own folder and the old `slug` value together (for example
+  `concepts/ab-testing` next to a `slug` of `ab-testing`) counts as a
+  match, since the shorter value is fully contained inside the longer one
+  — nothing is lost by keeping the longer `id` and dropping the duplicate
+  `slug`. This only happens when the replacement field is present, holds a
+  valid value, and matches the old one this way; if the two genuinely
+  disagree, both are left in place and the warning keeps showing, because
+  that mismatch needs a person to look at it, not an automatic guess.
+- The notice shown after an upgrade now separates what will be repaired
+  automatically from what still needs a person's judgment, and only names
+  the commands that actually apply to what was found — instead of always
+  suggesting the same two commands regardless of what is wrong.
+- `/lumi-ingest` now checks its own new and updated pages before marking an
+  entry done, instead of trusting that the step succeeded.
+  `/lumi-migrate-legacy` now also picks up the specific findings the
+  automatic repair leaves standing (an ambiguous link, a rating with no
+  safe default), not only the fields a Lumina version explicitly renamed.
 
 ### Fixed
 
@@ -33,11 +79,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   to: `1.12.0-next.0` and `1.12.0` looked identical to it. Version comparison
   now follows semver precedence — stable outranks its own pre-releases,
   numeric identifiers compare numerically, and build metadata is ignored.
-
-## [1.11.0] - 2026-07-27
-
-### Fixed
-
 - Six page templates (source, concept, person, summary, topic, foundation)
   had drifted out of step with the wiki's own rules: each one was missing
   required frontmatter fields (`id`, `created`, `updated`) and instead
@@ -131,52 +172,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the automatic repair can genuinely resolve before recommending it, rather
   than trusting an early guess, so it no longer points you at a repair that
   would decline the work.
-
-### Added
-
-- The six page templates above now match the wiki's frontmatter rules
-  exactly, and a new automated test compares every template against the
-  schema so they can't silently drift out of sync again.
-- `lint.mjs --fix` recovers more on its own now: an empty list for
-  list-type fields, a date recovered from an older field name or the
-  file's own save timestamp, a page's `id` recovered from an older field
-  name or its file path, its `type` from the folder it lives in, and its
-  title from the page's own heading. Where no safe value exists — a
-  publication year, an importance rating — it leaves the field reported as
-  missing instead of guessing, so a wrong value never quietly passes as
-  fixed.
-- `lint.mjs --fix` gained two further repairs: it corrects fields holding
-  the wrong kind of value (including rebuilding a page's source list and
-  related-concepts list straight from the link graph, which already held
-  the real answer), and it fixes wiki links that are missing their folder
-  name whenever exactly one page could be the intended target — never when
-  more than one page could match.
-- `lint.mjs --suggest` now actually does something. It had been accepted as
-  a flag since it shipped but silently did nothing; it now lists a concrete
-  next step for every finding the automatic repair could not resolve on its
-  own.
-- `lint.mjs --fix` now clears out an old field name once its replacement is
-  confirmed to hold the same information — for example, once a page's `id`
-  is in place, a leftover, older `slug` field carrying the identical value
-  is removed instead of being reported forever. "Matches" now also covers
-  the most common near-miss found in real wikis: an `id` that names both
-  its own folder and the old `slug` value together (for example
-  `concepts/ab-testing` next to a `slug` of `ab-testing`) counts as a
-  match, since the shorter value is fully contained inside the longer one
-  — nothing is lost by keeping the longer `id` and dropping the duplicate
-  `slug`. This only happens when the replacement field is present, holds a
-  valid value, and matches the old one this way; if the two genuinely
-  disagree, both are left in place and the warning keeps showing, because
-  that mismatch needs a person to look at it, not an automatic guess.
-- The notice shown after an upgrade now separates what will be repaired
-  automatically from what still needs a person's judgment, and only names
-  the commands that actually apply to what was found — instead of always
-  suggesting the same two commands regardless of what is wrong.
-- `/lumi-ingest` now checks its own new and updated pages before marking an
-  entry done, instead of trusting that the step succeeded.
-  `/lumi-migrate-legacy` now also picks up the specific findings the
-  automatic repair leaves standing (an ambiguous link, a rating with no
-  safe default), not only the fields a Lumina version explicitly renamed.
 
 ### Migration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-08-12
+
+> 1.11.0 was prepared in the changelog but never tagged, so it never reached
+> npm — the last published version was 1.10.1. Its fixes ship here.
+
 ### Added
 
 - Pre-release publishing channel. A tag whose version carries a pre-release
@@ -15,6 +20,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   identifier that cannot be read as one fails the publish rather than
   guessing — and such releases are marked as pre-releases on GitHub.
   Documented in `docs/DEVELOPMENT.md` §6.
+- Published packages now carry npm provenance. Every publish is signed with
+  the release workflow's OIDC identity, so npm can attest which repository,
+  commit and workflow run produced the tarball, and anyone can verify it
+  with `npm audit signatures`. A stolen npm token can no longer be used to
+  ship a package that looks like it came from this repository.
 
 ### Fixed
 
@@ -1039,7 +1049,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-[Unreleased]: https://github.com/tronghieu/lumina-wiki/compare/v1.11.0...HEAD
+[Unreleased]: https://github.com/tronghieu/lumina-wiki/compare/v1.12.0...HEAD
+[1.12.0]: https://github.com/tronghieu/lumina-wiki/compare/v1.10.1...v1.12.0
 [1.5.0]: https://github.com/tronghieu/lumina-wiki/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/tronghieu/lumina-wiki/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/tronghieu/lumina-wiki/compare/v1.2.0...v1.3.0

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -132,7 +132,7 @@ npm run test:update        # update-check timeouts
 
 Publishing is tag-driven: pushing a `v*` tag runs `.github/workflows/publish.yml`, which re-runs the gates against the tagged commit, publishes to npm, and opens a GitHub Release from the matching `CHANGELOG.md` entry.
 
-Publishing happens **only** from that workflow. `npm publish` runs with `--provenance`, which signs the tarball with the workflow's OIDC identity so npm can attest which repository, commit and run built it — a publish from a laptop has no such identity and fails.
+Publish from that workflow, never from a laptop. `npm publish` runs with `--provenance`, which signs the tarball with the workflow's OIDC identity so npm can attest which repository, commit and run built it. A publish run anywhere else cannot produce that attestation: npm does not refuse it, but the package lands with no provenance, which is visible on npmjs.com and to `npm audit signatures`.
 
 The npm dist-tag is derived from the version itself — the workflow never takes it as an input:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -132,6 +132,8 @@ npm run test:update        # update-check timeouts
 
 Publishing is tag-driven: pushing a `v*` tag runs `.github/workflows/publish.yml`, which re-runs the gates against the tagged commit, publishes to npm, and opens a GitHub Release from the matching `CHANGELOG.md` entry.
 
+Publishing happens **only** from that workflow. `npm publish` runs with `--provenance`, which signs the tarball with the workflow's OIDC identity so npm can attest which repository, commit and run built it — a publish from a laptop has no such identity and fails.
+
 The npm dist-tag is derived from the version itself — the workflow never takes it as an input:
 
 | `package.json` version | git tag | npm dist-tag | GitHub Release |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumina-wiki",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumina-wiki",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "lumina-wiki",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Domain-agnostic, multi-IDE wiki scaffolder — Karpathy's LLM-Wiki vision, cross-platform and pack-based.",
   "keywords": [
     "llm-wiki",


### PR DESCRIPTION
## Summary

Adds `--provenance` to the publish step and cuts 1.12.0 with it.

Provenance signs each publish with the release workflow's OIDC identity — the `id-token: write` permission the job already held — so npm records which repository, commit and workflow run produced the tarball, and anyone can verify it with `npm audit signatures`. It is detection, not prevention: someone holding a valid npm token can still publish without the flag, but that package arrives with no attestation at all, and the absence is visible on npmjs.com and to anyone verifying. For a CLI that writes agent-readable skill prompts into a user's project, being able to prove which commit built the tarball is worth the one flag.

**1.11.0 was never published.** `package.json` and `CHANGELOG.md` were bumped in #36 but no `v1.11.0` tag was ever pushed, so the workflow never fired — `npm view lumina-wiki dist-tags` still reports `latest: 1.10.1`. Its changelog entries are folded into 1.12.0 here, since a heading for a version that never reached npm claims a release that does not exist.

## Type of change

- [x] Other (release tooling + version bump)

## What changed

| File | Change |
|---|---|
| `.github/workflows/publish.yml` | `npm publish --provenance --tag <channel>` |
| `package.json` + `package-lock.json` | `1.11.0` → `1.12.0` (both, via `npm version`) |
| `CHANGELOG.md` | 1.11.0's `Added` / `Fixed` / `Migration` entries merged into `## [1.12.0] - 2026-08-12`; provenance entry added |
| `docs/DEVELOPMENT.md` | §6 notes that publishing only ever happens from the workflow, and what provenance does and does not guarantee |

The `[1.12.0]` compare link is based on `v1.10.1`, not `v1.11.0` — the latter does not exist as a tag and the link would 404.

## Requirements for provenance, all already satisfied

- Public repository — yes
- Publishing from GitHub Actions — yes
- `id-token: write` on the job — already present since #33
- `repository` field in `package.json` matching the building repo — matches
- npm ≥ 9.5 — the workflow runs Node 24

## Review round

Three P2s from Codex on the first commit, all valid, all fixed in 0134fbc:

1. **Lockfile left at 1.11.0.** `npm ci` tolerates the mismatch so no gate would have caught it — but every prior release commit here (`78a12f7`, `420b0c2`, `d32a92f`, `6c31ff8`) bumps the lockfile alongside `package.json`.
2. **Release notes would have omitted the 1.11.0 section.** The workflow's `awk` extraction stops at the next `## [` heading, so tagging `v1.12.0` would have published notes covering three entries while silently dropping the thirty that ship with them. Verified after folding: extraction now yields 191 lines and 33 entries across all three subsections.
3. **Provenance claim overstated.** The original wording said a stolen token could no longer ship a package looking like it came from this repo. That is false without an npm access policy enforcing trusted publishing, which this repo does not have. Reworded in both the changelog and the docs.

## Trilingual docs

- [x] N/A — no user-facing surface changed

## Tests

- [x] `npm run test:installer` — 283 pass, 2 skipped, 0 fail
- [x] `npm run test:scripts` — 468 pass
- [x] `npm run test:catalog` — 11 pass
- [x] `npm run ci:idempotency` — all 5 scenarios clean
- [x] `npm run ci:package` — `lumina-wiki@1.12.0`, 113 files
- [ ] `npm run test:python` — not run; pytest unavailable in this container. No Python file is touched.

`publish.yml` re-validated as parseable YAML, and the release-notes `awk` block was run against the rewritten changelog.

## After merge

Nothing publishes until a tag is pushed. `git tag v1.12.0 && git push origin --tags` ships to `latest`; a `v1.12.0-next.0` tag (with `package.json` bumped to match) would exercise the pre-release channel first without moving `latest`.

## Rule deviations

None.

## Related issues / PRs

Follows #37, which added the pre-release channel this builds on.