### PR TITLE
refactor(scripts): one definition per rule in src/scripts/

### DIFF
--- a/src/installer/commands.js
+++ b/src/installer/commands.js
@@ -14,7 +14,7 @@
  *   7. Print summary tree
  */
 
-import { readFile, writeFile, rename, unlink, rm, access, lstat, realpath, readlink } from 'node:fs/promises';
+import { readFile, writeFile, rename, unlink, rm, access, lstat, realpath, readlink, readdir } from 'node:fs/promises';
 import { join, resolve, relative, dirname, basename, isAbsolute } from 'node:path';
 import { constants as fsConstants } from 'node:fs';
 import { spawnSync } from 'node:child_process';
@@ -1479,10 +1479,19 @@ async function copyScripts(projectRoot) {
       // Scripts may not exist yet (P4+ work); skip gracefully
     }
   }));
-  // Ensure the lib subdir once, then parallelize the file copies.
+  // Ensure the lib subdir once, then parallelize the file copies. The list is
+  // read from the package instead of hardcoded: wiki.mjs and lint.mjs import
+  // shared helpers from lib/, so a lib file missing from the workspace breaks
+  // every skill at runtime — and the catch below would hide that at install
+  // time. Reading the directory keeps the two in step by construction.
   const libDir = join(destDir, 'lib');
   await ensureDir(libDir);
-  const libFiles = ['watchlist-config.mjs', 'discovery-state.mjs'];
+  let libFiles = [];
+  try {
+    libFiles = (await readdir(join(SCRIPTS_DIR, 'lib'))).filter(f => f.endsWith('.mjs'));
+  } catch (_) {
+    // No lib/ in this package snapshot; nothing to copy.
+  }
   await Promise.all(libFiles.map(async file => {
     try {
       await atomicCopyFile(join(SCRIPTS_DIR, 'lib', file), join(libDir, file));

--- a/src/scripts/discover-runner.mjs
+++ b/src/scripts/discover-runner.mjs
@@ -6,7 +6,12 @@ import { basename, join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
-import { loadWatchlistConfig, WatchlistConfigError } from './lib/watchlist-config.mjs';
+import {
+  loadWatchlistConfig,
+  WatchlistConfigError,
+  VALID_SCHEDULES,
+  VALID_SOURCES,
+} from './lib/watchlist-config.mjs';
 import {
   getItemState,
   hasSeen,
@@ -17,8 +22,13 @@ import {
 import { atomicWrite } from './lib/fsx.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
-const VALID_SCHEDULES = new Set(['manual', 'daily', 'weekly', 'monthly']);
-const VALID_SOURCES = new Set(['arxiv', 's2', 'openalex', 'rss']);
+/**
+ * What `--source` accepts on the CLI: the fetchable providers plus `rss`,
+ * which selects feed items rather than a per-topic search source. Kept
+ * separate from VALID_SOURCES so the filter set and the fetcher dispatch set
+ * are visibly different rather than accidentally so.
+ */
+const VALID_CLI_SOURCES = new Set([...VALID_SOURCES, 'rss']);
 
 export async function runDiscover(options = {}) {
   const projectRoot = resolve(options.projectRoot ?? process.cwd());
@@ -202,21 +212,19 @@ function fetchFeed({ projectRoot, item, maxNew }) {
   }));
 }
 
+/** Per-provider fetcher: script name and the flag it spells `limit` with. */
+const FETCHERS = {
+  arxiv:    { script: 'fetch_arxiv.py',    limitFlag: '--max' },
+  s2:       { script: 'fetch_s2.py',       limitFlag: '--limit' },
+  openalex: { script: 'fetch_openalex.py', limitFlag: '--limit' },
+};
+
 function fetchSource({ projectRoot, source, query, limit }) {
-  if (!VALID_SOURCES.has(source)) throw new Error(`Unknown source: ${source}`);
+  const fetcher = FETCHERS[source];
+  if (!fetcher) throw new Error(`Unknown source: ${source}`);
   const toolsDir = join(projectRoot, '_lumina', 'tools');
-  const scriptByName = {
-    arxiv: 'fetch_arxiv.py',
-    s2: 'fetch_s2.py',
-    openalex: 'fetch_openalex.py',
-  };
-  const script = scriptByName[source];
-  const argsByName = {
-    arxiv: [join(toolsDir, script), 'search', query, '--max', String(limit)],
-    s2: [join(toolsDir, script), 'search', query, '--limit', String(limit)],
-    openalex: [join(toolsDir, script), 'search', query, '--limit', String(limit)],
-  };
-  const args = argsByName[source];
+  const script = fetcher.script;
+  const args = [join(toolsDir, script), 'search', query, fetcher.limitFlag, String(limit)];
   const result = spawnSync('python3', args, {
     cwd: projectRoot,
     encoding: 'utf8',
@@ -438,7 +446,7 @@ function safeFilePart(value) {
 function normalizeSourceFilter(value) {
   if (!value || value === 'all') return null;
   const source = String(value).trim().toLowerCase();
-  if (!VALID_SOURCES.has(source)) throw new WatchlistConfigError(`Unknown source "${source}".`);
+  if (!VALID_CLI_SOURCES.has(source)) throw new WatchlistConfigError(`Unknown source "${source}".`);
   return source;
 }
 

--- a/src/scripts/discover-runner.mjs
+++ b/src/scripts/discover-runner.mjs
@@ -16,7 +16,6 @@ import {
 } from './lib/discovery-state.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
 const VALID_SCHEDULES = new Set(['manual', 'daily', 'weekly', 'monthly']);
 const VALID_SOURCES = new Set(['arxiv', 's2', 'openalex', 'rss']);
 

--- a/src/scripts/discover-runner.mjs
+++ b/src/scripts/discover-runner.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import { createHash } from 'node:crypto';
 import { constants as fsConstants } from 'node:fs';
-import { access, mkdir, readdir, readFile, rename, unlink, open } from 'node:fs/promises';
-import { basename, dirname, join, resolve } from 'node:path';
+import { access, readdir, readFile } from 'node:fs/promises';
+import { basename, join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
@@ -14,6 +14,7 @@ import {
   readDiscoveryState,
   writeDiscoveryState,
 } from './lib/discovery-state.mjs';
+import { atomicWrite } from './lib/fsx.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const VALID_SCHEDULES = new Set(['manual', 'daily', 'weekly', 'monthly']);
@@ -359,25 +360,6 @@ async function writeCandidate(filePath, record) {
   await atomicWrite(filePath, `${JSON.stringify(record, null, 2)}\n`);
 }
 
-async function atomicWrite(filePath, content) {
-  await mkdir(dirname(filePath), { recursive: true });
-  const tmpPath = `${filePath}.tmp`;
-  let fd;
-  try {
-    fd = await open(tmpPath, 'w');
-    await fd.writeFile(content, 'utf8');
-    await fd.datasync();
-    await fd.close();
-    fd = null;
-    await rename(tmpPath, filePath);
-  } catch (err) {
-    if (fd) {
-      try { await fd.close(); } catch (_) {}
-    }
-    await unlink(tmpPath).catch(() => {});
-    throw err;
-  }
-}
 
 function printSummary(summary) {
   console.log([

--- a/src/scripts/lib/discovery-state.mjs
+++ b/src/scripts/lib/discovery-state.mjs
@@ -1,5 +1,5 @@
-import { mkdir, readFile, rename, unlink, open } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { atomicWrite } from './fsx.mjs';
 
 export function emptyDiscoveryState() {
   return { version: 1, items: {} };
@@ -38,23 +38,4 @@ export function hasSeen(itemState, dedupKey) {
   return Object.prototype.hasOwnProperty.call(itemState.seen ?? {}, dedupKey);
 }
 
-async function atomicWrite(filePath, content) {
-  await mkdir(dirname(filePath), { recursive: true });
-  const tmpPath = `${filePath}.tmp`;
-  let fd;
-  try {
-    fd = await open(tmpPath, 'w');
-    await fd.writeFile(content, 'utf8');
-    await fd.datasync();
-    await fd.close();
-    fd = null;
-    await rename(tmpPath, filePath);
-  } catch (err) {
-    if (fd) {
-      try { await fd.close(); } catch (_) {}
-    }
-    await unlink(tmpPath).catch(() => {});
-    throw err;
-  }
-}
 

--- a/src/scripts/lib/edges.mjs
+++ b/src/scripts/lib/edges.mjs
@@ -1,0 +1,91 @@
+/**
+ * @file edges.mjs
+ * @description Graph-edge primitives shared by the writer (wiki.mjs) and the
+ * checker (lint.mjs). Pure — no I/O, no side effects.
+ *
+ * The reverse-edge gate is the project's headline invariant, and it used to be
+ * spelled out in six places: inline in addEdge and batchEdges, via a
+ * skipReverseFor() helper in removeEdge and replaceEdge, and open-coded again
+ * in lint's checkL06 and fixL06. Worse, the helper was an incomplete copy — it
+ * omitted the `typeDef.reverse` check its callers each added by hand, so a
+ * caller trusting it alone would have written an edge with `type: null` for
+ * the one EDGE_TYPES entry (`appears_in`) that has a null reverse and no
+ * terminal flag. One definition now, with that check folded in.
+ */
+
+import { EDGE_TYPES } from '../schemas.mjs';
+import { isExempt } from './globs.mjs';
+
+/** Name -> EDGE_TYPES entry. Built once; the array is static, 42 entries. */
+const BY_NAME = new Map(EDGE_TYPES.map(t => [t.name, t]));
+
+/**
+ * Look up an edge type definition by name.
+ * @param {string} name
+ * @returns {object|null} The EDGE_TYPES entry, or null when unknown.
+ */
+export function edgeTypeByName(name) {
+  return BY_NAME.get(name) ?? null;
+}
+
+/**
+ * Whether a forward edge of this type is allowed to exist without a reverse:
+ * the type declares no reverse, is terminal, is symmetric (sorted endpoints
+ * already cover both directions), or the target is exemption-matched.
+ * @param {object} typeDef An EDGE_TYPES entry.
+ * @param {string} toSlug  The forward edge's target.
+ * @returns {boolean}
+ */
+export function skipReverseFor(typeDef, toSlug) {
+  return Boolean(
+    !typeDef.reverse || typeDef.terminal || typeDef.symmetric || isExempt(toSlug),
+  );
+}
+
+/**
+ * Build the reverse of a forward edge, or null when the gate says there is
+ * none. The single place a reverse edge is constructed.
+ * @param {object} typeDef      An EDGE_TYPES entry.
+ * @param {string} fromSlug     The forward edge's source.
+ * @param {string} toSlug       The forward edge's target.
+ * @param {string} [confidence] Carried over from the forward edge when set.
+ * @returns {object|null}
+ */
+export function reverseEdgeFor(typeDef, fromSlug, toSlug, confidence) {
+  if (skipReverseFor(typeDef, toSlug)) return null;
+  return {
+    from: toSlug,
+    type: typeDef.reverse,
+    to: fromSlug,
+    ...(confidence ? { confidence } : {}),
+  };
+}
+
+/**
+ * Identity key for an edge, ignoring confidence. Symmetric types sort their
+ * endpoints so the two storage orders collapse to one key.
+ * @param {object} edge
+ * @returns {string}
+ */
+export function edgeKey(edge) {
+  const typeDef = BY_NAME.get(edge.type);
+  if (typeDef && typeDef.symmetric) {
+    const endpoints = [edge.from, edge.to].sort();
+    return `${endpoints[0]}|${edge.type}|${endpoints[1]}`;
+  }
+  return `${edge.from}|${edge.type}|${edge.to}`;
+}
+
+/**
+ * Canonical storage form of an edge: symmetric types get sorted endpoints.
+ * @param {object} edge
+ * @returns {object}
+ */
+export function normalizeEdge(edge) {
+  const typeDef = BY_NAME.get(edge.type);
+  if (typeDef && typeDef.symmetric) {
+    const [a, b] = [edge.from, edge.to].sort();
+    return { ...edge, from: a, to: b };
+  }
+  return edge;
+}

--- a/src/scripts/lib/fsx.mjs
+++ b/src/scripts/lib/fsx.mjs
@@ -1,0 +1,46 @@
+/**
+ * @file fsx.mjs
+ * @description Filesystem primitives shared by every script in this layer.
+ *
+ * `atomicWrite` used to exist as four separate copies (wiki.mjs, lint.mjs,
+ * discover-runner.mjs, lib/discovery-state.mjs) plus a bare `writeFile` in
+ * reset.mjs. They had already drifted: the lint copy wrote with `writeFile`
+ * and renamed without ever calling `fd.datasync()`, so `lint --fix` — the
+ * widest-blast-radius mutation path in the project — ran without the
+ * durability guarantee the other copies provide. One implementation, taking
+ * the strictest behaviour of the set.
+ */
+
+import { mkdir, open, rename, unlink } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+/**
+ * Write `content` to `filePath` atomically: create the parent directory,
+ * write to `<filePath>.tmp`, fsync the descriptor, then rename into place.
+ * The temp file is removed on failure so a crash never leaves a partial
+ * sibling behind.
+ *
+ * @param {string} filePath Destination path.
+ * @param {string} content  UTF-8 content to write.
+ * @returns {Promise<void>}
+ */
+export async function atomicWrite(filePath, content) {
+  await mkdir(dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp`;
+  let fd;
+  try {
+    fd = await open(tmpPath, 'w');
+    await fd.writeFile(content, 'utf8');
+    await fd.datasync();
+    await fd.close();
+    fd = null;
+    await rename(tmpPath, filePath);
+  } catch (err) {
+    if (fd) {
+      try { await fd.close(); } catch (_) { /* ignore */ }
+    }
+    // Best-effort cleanup of the temp file.
+    await unlink(tmpPath).catch(() => {});
+    throw err;
+  }
+}

--- a/src/scripts/lib/globs.mjs
+++ b/src/scripts/lib/globs.mjs
@@ -1,0 +1,73 @@
+/**
+ * @file globs.mjs
+ * @description The exemption-glob matcher behind the bidirectional-link
+ * invariant. Pure — no I/O, no side effects.
+ *
+ * wiki.mjs decides whether to *write* a reverse edge and lint.mjs decides
+ * whether to *report* a missing one. Both read EXEMPTION_GLOBS from
+ * schemas.mjs, but each used to interpret it with its own matcher: wiki.mjs
+ * compiled a general glob, lint.mjs special-cased exactly three shapes. They
+ * agreed only on the four globs shipped today — adding a single-`*` glob to
+ * schemas.mjs would have made wiki.mjs skip a reverse edge that lint.mjs then
+ * wrote back on every `--fix`. One matcher, so that cannot happen.
+ */
+
+import { EXEMPTION_GLOBS } from '../schemas.mjs';
+
+/** Matches the `*://*` pattern: any URL-shaped target. */
+const URL_RE = /^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//;
+
+/**
+ * Compile a glob supporting `*` (within one path segment) and `**` (any).
+ * @param {string} pattern
+ * @returns {RegExp}
+ */
+function compileGlob(pattern) {
+  const body = pattern
+    .replace(/\\/g, '/')
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&') // escape regex special chars
+    .replace(/\*\*/g, '{{DOUBLESTAR}}')
+    .replace(/\*/g, '[^/]*')
+    .replace(/{{DOUBLESTAR}}/g, '.*');
+  return new RegExp(`^${body}$`);
+}
+
+/** Compiled-glob cache, so a repeated pattern is compiled once per process. */
+const _compiled = new Map();
+
+/**
+ * Simple glob matcher supporting `*` and `**`, plus the `*://*` URL pattern.
+ * @param {string} pattern
+ * @param {string} str
+ * @returns {boolean}
+ */
+export function matchGlob(pattern, str) {
+  const p = pattern.replace(/\\/g, '/');
+  const s = str.replace(/\\/g, '/');
+  if (p === '*://*') return URL_RE.test(s);
+  let re = _compiled.get(p);
+  if (!re) {
+    re = compileGlob(p);
+    _compiled.set(p, re);
+  }
+  return re.test(s);
+}
+
+/** EXEMPTION_GLOBS is static, so compile it once at module load. */
+const EXEMPTION_MATCHERS = EXEMPTION_GLOBS.map(glob =>
+  glob === '*://*' ? (s) => URL_RE.test(s) : ((re) => (s) => re.test(s))(compileGlob(glob)),
+);
+
+/**
+ * Check whether a target slug/path matches any exemption glob — i.e. whether
+ * a forward edge to it is allowed to exist without a reverse.
+ * @param {string} target
+ * @returns {boolean}
+ */
+export function isExempt(target) {
+  const s = target.replace(/\\/g, '/');
+  for (const match of EXEMPTION_MATCHERS) {
+    if (match(s)) return true;
+  }
+  return false;
+}

--- a/src/scripts/lib/watchlist-config.mjs
+++ b/src/scripts/lib/watchlist-config.mjs
@@ -1,8 +1,17 @@
 import { readFile } from 'node:fs/promises';
 import { isAbsolute } from 'node:path';
 
-const VALID_SCHEDULES = new Set(['manual', 'daily', 'weekly', 'monthly']);
-const VALID_SOURCES = new Set(['arxiv', 's2', 'openalex']);
+/** Schedules a watchlist item may declare. */
+export const VALID_SCHEDULES = new Set(['manual', 'daily', 'weekly', 'monthly']);
+
+/**
+ * Providers a `topic` item may list under `sources`. `rss` is deliberately
+ * NOT here: it is a feed provider reached through an item's `url`, never a
+ * per-topic search source. discover-runner's CLI --source filter accepts it
+ * as an extra token (VALID_CLI_SOURCES there) precisely because the two sets
+ * are different, not because one of them is out of date.
+ */
+export const VALID_SOURCES = new Set(['arxiv', 's2', 'openalex']);
 const VALID_ITEM_TYPES = new Set(['topic', 'feed']);
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 100;

--- a/src/scripts/lint.mjs
+++ b/src/scripts/lint.mjs
@@ -1634,16 +1634,25 @@ function checkL11(wikiRelPath, fm) {
  * @param {Record<string,unknown>} fm
  * @returns {Finding[]}
  */
-function checkL13(wikiRelPath, fm) {
-  const type = entityTypeForPath(wikiRelPath);
-  if (type !== 'sources') return [];
+/**
+ * Shared preamble for L13 and L16: both only apply to source pages with
+ * urls[], and both need the same two things — the declared external_ids
+ * mapping, and the non-url namespaces derivable from urls[] (deduped by
+ * namespace, first url wins). Parsing every url twice per page was the only
+ * difference between the two copies.
+ *
+ * @param {string} wikiRelPath
+ * @param {Record<string,any>} fm
+ * @returns {{ext: Record<string,any>, derived: Record<string,string>}|null}
+ *   null when the checks do not apply to this page.
+ */
+function deriveNamespacesFromUrls(wikiRelPath, fm) {
+  if (entityTypeForPath(wikiRelPath) !== 'sources') return null;
   const urls = Array.isArray(fm.urls) ? fm.urls.filter(u => typeof u === 'string') : [];
-  if (urls.length === 0) return [];
+  if (urls.length === 0) return null;
   const ext = (fm.external_ids && typeof fm.external_ids === 'object' && !Array.isArray(fm.external_ids))
     ? fm.external_ids
     : {};
-
-  // Collect derived non-url namespaces across all urls; dedupe by namespace.
   const derived = {};
   for (const url of urls) {
     const ids = parseUrlToExternalIds(url);
@@ -1652,6 +1661,13 @@ function checkL13(wikiRelPath, fm) {
       if (!(ns in derived)) derived[ns] = ids[ns];
     }
   }
+  return { ext, derived };
+}
+
+function checkL13(wikiRelPath, fm) {
+  const ctx = deriveNamespacesFromUrls(wikiRelPath, fm);
+  if (!ctx) return [];
+  const { ext, derived } = ctx;
   const findings = [];
   for (const [ns, val] of Object.entries(derived)) {
     const cur = ext[ns];
@@ -1701,22 +1717,9 @@ function checkL14(wikiRelPath, fm) {
  * @returns {Finding[]}
  */
 function checkL16(wikiRelPath, fm) {
-  const type = entityTypeForPath(wikiRelPath);
-  if (type !== 'sources') return [];
-  const urls = Array.isArray(fm.urls) ? fm.urls.filter(u => typeof u === 'string') : [];
-  const ext = (fm.external_ids && typeof fm.external_ids === 'object' && !Array.isArray(fm.external_ids))
-    ? fm.external_ids
-    : {};
-  if (urls.length === 0) return [];
-
-  const derived = {};
-  for (const url of urls) {
-    const ids = parseUrlToExternalIds(url);
-    for (const ns of Object.keys(ids)) {
-      if (ns === 'url') continue;
-      if (!(ns in derived)) derived[ns] = ids[ns];
-    }
-  }
+  const ctx = deriveNamespacesFromUrls(wikiRelPath, fm);
+  if (!ctx) return [];
+  const { ext, derived } = ctx;
   const findings = [];
   for (const [ns, urlVal] of Object.entries(derived)) {
     const cur = ext[ns];
@@ -2301,6 +2304,32 @@ async function runLint(projectRoot, opts) {
 }
 
 /**
+ * Run a fixer that rewrites one whole file, and mark its findings.
+ *
+ * @param {object[]} findings   All findings for this run.
+ * @param {string} id           Finding id this fixer owns.
+ * @param {string} targetPath   File the fixer rewrites.
+ * @param {() => Promise<string>} readCurrent  Reads the file's current content.
+ *   A thunk, not a value: the read must not happen when there is nothing to
+ *   fix, and must happen after any earlier fixer wrote to the same file.
+ * @param {(current: string) => {newContent: string, preview: string}} runFixer
+ * @param {object} opts
+ */
+async function applyWholeFileFix(findings, id, targetPath, readCurrent, runFixer, opts) {
+  const hits = findings.filter(f => f.id === id);
+  if (hits.length === 0) return;
+  const current = await readCurrent();
+  const { newContent, preview } = runFixer(current);
+  if (newContent === current) return;
+  if (opts.dryRun) {
+    for (const f of hits) { f.proposed_fix = preview; }
+    return;
+  }
+  await atomicWrite(targetPath, newContent);
+  for (const f of hits) { f.fix_applied = true; }
+}
+
+/**
  * Apply fixes for fixable findings.
  * @param {Set<string>} knownSlugs  Wiki-relative slugs (no `.md`) of every
  *   known file — threaded into fixL02 for its tier-2 body-wikilink fallback.
@@ -2423,51 +2452,18 @@ async function applyFixes(findings, wikiRoot, edgesPath, indexPath, indexContent
     }
   }
 
-  // Fix L06.
-  const l06findings = findings.filter(f => f.id === 'L06-missing-reverse-edge');
-  if (l06findings.length > 0) {
-    let edgesContent = '';
-    try { edgesContent = await readFile(edgesPath, 'utf8'); } catch {}
-    const { newContent, preview } = fixL06(edgesPath, edgesContent, edges, edgeSet);
-    if (newContent !== edgesContent) {
-      if (opts.dryRun) {
-        for (const f of l06findings) { f.proposed_fix = preview; }
-      } else {
-        await atomicWrite(edgesPath, newContent);
-        for (const f of l06findings) { f.fix_applied = true; }
-      }
-    }
-  }
-
-  // Fix L07.
-  const l07findings = findings.filter(f => f.id === 'L07-symmetric-edge-duplicate');
-  if (l07findings.length > 0) {
-    let edgesContent = '';
-    try { edgesContent = await readFile(edgesPath, 'utf8'); } catch {}
-    const { newContent, preview } = fixL07(edgesContent, edges);
-    if (newContent !== edgesContent) {
-      if (opts.dryRun) {
-        for (const f of l07findings) { f.proposed_fix = preview; }
-      } else {
-        await atomicWrite(edgesPath, newContent);
-        for (const f of l07findings) { f.fix_applied = true; }
-      }
-    }
-  }
-
-  // Fix L09.
-  const l09findings = findings.filter(f => f.id === 'L09-index-stale');
-  if (l09findings.length > 0) {
-    const { newContent, preview } = fixL09(indexContent, entityFiles.filter(f => !isIndexExempt(f)));
-    if (newContent !== indexContent) {
-      if (opts.dryRun) {
-        for (const f of l09findings) { f.proposed_fix = preview; }
-      } else {
-        await atomicWrite(indexPath, newContent);
-        for (const f of l09findings) { f.fix_applied = true; }
-      }
-    }
-  }
+  // L06/L07/L09 each rewrite one whole file; the three blocks differed only in
+  // the finding id, the target, and the fixer call.
+  const readEdges = async () => {
+    try { return await readFile(edgesPath, 'utf8'); } catch { return ''; }
+  };
+  await applyWholeFileFix(findings, 'L06-missing-reverse-edge', edgesPath, readEdges,
+    current => fixL06(edgesPath, current, edges, edgeSet), opts);
+  // Deliberately re-reads: under --fix, L06 has already rewritten this file.
+  await applyWholeFileFix(findings, 'L07-symmetric-edge-duplicate', edgesPath, readEdges,
+    current => fixL07(current, edges), opts);
+  await applyWholeFileFix(findings, 'L09-index-stale', indexPath, async () => indexContent,
+    current => fixL09(current, entityFiles.filter(f => !isIndexExempt(f))), opts);
 
   // Truth pass. `fixable` is decided at check time from the finding's shape
   // alone, before any fixer has looked at the file, so it is a prediction. Some

--- a/src/scripts/lint.mjs
+++ b/src/scripts/lint.mjs
@@ -51,7 +51,6 @@ import { join, basename, dirname, relative, normalize, resolve } from 'node:path
 import {
   SCHEMA_VERSION,
   ENTITY_DIRS,
-  EDGE_TYPES,
   REQUIRED_FRONTMATTER,
 } from './schemas.mjs';
 import {
@@ -61,6 +60,12 @@ import {
 } from './external-ids.mjs';
 import { atomicWrite } from './lib/fsx.mjs';
 import { isExempt } from './lib/globs.mjs';
+import {
+  edgeTypeByName,
+  skipReverseFor,
+  reverseEdgeFor,
+  edgeKey,
+} from './lib/edges.mjs';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // CONSTANTS
@@ -1361,11 +1366,8 @@ function checkL05(wikiRelPath, rawContent, knownSlugs) {
 function checkL06(edges, edgeSet) {
   const findings = [];
   for (const edge of edges) {
-    if (isExempt(edge.to)) continue;
-    const edgeType = EDGE_TYPES.find(et => et.name === edge.type);
-    if (!edgeType) continue;
-    if (edgeType.terminal || edgeType.reverse === null) continue;
-    if (edgeType.symmetric) continue; // L07 handles symmetric
+    const edgeType = edgeTypeByName(edge.type);
+    if (!edgeType || skipReverseFor(edgeType, edge.to)) continue; // L07 handles symmetric
 
     const reverseKey = `${edge.to}|${edgeType.reverse}|${edge.from}`;
     if (!edgeSet.has(reverseKey)) {
@@ -1389,25 +1391,17 @@ function checkL07(edges, edgeSet) {
   const findings = [];
   const seen = new Set();
   for (const edge of edges) {
-    const edgeType = EDGE_TYPES.find(et => et.name === edge.type);
+    const edgeType = edgeTypeByName(edge.type);
     if (!edgeType || !edgeType.symmetric) continue;
 
-    const [a, b] = [edge.from, edge.to].sort();
-    const canonical = `${a}|${edge.type}|${b}`;
+    const canonical = edgeKey(edge);
     const reverse = `${edge.to}|${edge.type}|${edge.from}`;
 
-    if (!seen.has(canonical)) {
-      seen.add(canonical);
-      // Check if both orderings appear in edgeSet (stored both ways)
-      if (edgeSet.has(reverse) && edge.from !== edge.to) {
-        findings.push(finding(
-          'L07-symmetric-edge-duplicate', 'warning', true,
-          edge.from, null,
-          `Symmetric edge "${edge.type}" stored both ways between "${edge.from}" and "${edge.to}"; should be stored once with sorted endpoints`
-        ));
-      }
-    } else {
-      // Duplicate line (same canonical key seen again)
+    // Either ordering already seen, or both orderings present in the file.
+    const duplicate = seen.has(canonical)
+      || (edgeSet.has(reverse) && edge.from !== edge.to);
+    seen.add(canonical);
+    if (duplicate) {
       findings.push(finding(
         'L07-symmetric-edge-duplicate', 'warning', true,
         edge.from, null,
@@ -1426,7 +1420,7 @@ function checkL07(edges, edgeSet) {
 function checkL08(edges) {
   const findings = [];
   for (const edge of edges) {
-    const edgeType = EDGE_TYPES.find(et => et.name === edge.type);
+    const edgeType = edgeTypeByName(edge.type);
     if (!edgeType || !edgeType.confidenceRequired) continue;
 
     const validConfidence = ['high', 'medium', 'low'];
@@ -2076,15 +2070,12 @@ async function fixL05(wikiRelPath, wikiRoot, l05findings, pendingRenames = new S
 function fixL06(edgesPath, edgesContent, edges, edgeSet) {
   const toAdd = [];
   for (const edge of edges) {
-    if (isExempt(edge.to)) continue;
-    const edgeType = EDGE_TYPES.find(et => et.name === edge.type);
-    if (!edgeType || edgeType.terminal || edgeType.reverse === null) continue;
-    if (edgeType.symmetric) continue;
+    const edgeType = edgeTypeByName(edge.type);
+    if (!edgeType || skipReverseFor(edgeType, edge.to)) continue;
 
     const reverseKey = `${edge.to}|${edgeType.reverse}|${edge.from}`;
     if (!edgeSet.has(reverseKey)) {
-      const revEdge = { from: edge.to, to: edge.from, type: edgeType.reverse };
-      if (edge.confidence) revEdge.confidence = edge.confidence;
+      const revEdge = reverseEdgeFor(edgeType, edge.from, edge.to, edge.confidence);
       toAdd.push(revEdge);
       edgeSet.add(reverseKey); // prevent duplicate adds in same run
     }
@@ -2108,7 +2099,7 @@ function fixL07(edgesContent, edges) {
   const removed = [];
 
   for (const edge of edges) {
-    const edgeType = EDGE_TYPES.find(et => et.name === edge.type);
+    const edgeType = edgeTypeByName(edge.type);
     if (!edgeType || !edgeType.symmetric) {
       const key = `${edge.from}|${edge.type}|${edge.to}`;
       canonical.set(key, edge);

--- a/src/scripts/lint.mjs
+++ b/src/scripts/lint.mjs
@@ -1067,8 +1067,30 @@ function entityTypeForPath(wikiRelPath) {
  * @param {string} message
  * @returns {Finding}
  */
-function finding(id, severity, fixable, file, line, message) {
-  return { id, severity, fixable, file, line, message, fix_applied: false };
+function finding(id, severity, fixable, file, line, message, extra) {
+  return { id, severity, fixable, file, line, message, fix_applied: false, ...extra };
+}
+
+/**
+ * Build an L02 type-violation finding. The key, the schema type and the
+ * expected-type phrase travel as fields; the fixers and computeSuggestion
+ * read those instead of regex-ing them back out of `message`, which coupled
+ * ten call sites to the exact wording of two English sentences.
+ * reportJson strips them from the public --json shape.
+ *
+ * @param {string} wikiRelPath
+ * @param {{key: string, type: string}} field
+ * @param {boolean} fixable
+ * @param {string} expected  Phrase after "must be", e.g. `an array`.
+ * @param {string} got       Phrase after "got".
+ * @returns {object}
+ */
+function l02TypeFinding(wikiRelPath, field, fixable, expected, got) {
+  return finding(
+    'L02-frontmatter-types', 'error', fixable, wikiRelPath, null,
+    `"${field.key}" must be ${expected}, got ${got}`,
+    { key: field.key, fieldType: field.type, expected },
+  );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1123,7 +1145,8 @@ function checkL01(wikiRelPath, fm) {
       findings.push(finding(
         'L01-frontmatter-required', 'error', isL01Fixable(type, field),
         wikiRelPath, null,
-        `Missing required frontmatter key: "${field.key}" (type: ${field.type})`
+        `Missing required frontmatter key: "${field.key}" (type: ${field.type})`,
+        { key: field.key, fieldType: field.type },
       ));
     }
   }
@@ -1149,8 +1172,7 @@ function checkL02(wikiRelPath, fm) {
     switch (field.type) {
       case 'string':
         if (typeof val !== 'string') {
-          findings.push(finding('L02-frontmatter-types', 'error', false, wikiRelPath, null,
-            `"${field.key}" must be a string, got ${typeof val}`));
+          findings.push(l02TypeFinding(wikiRelPath, field, false, 'a string', `${typeof val}`));
         } else if (val.trim() === 'TODO') {
           // Task 2 sentinel rule: the exact literal "TODO" (trimmed,
           // case-sensitive) is never a real value for a DECLARED schema
@@ -1163,14 +1185,15 @@ function checkL02(wikiRelPath, fm) {
           // entity type (we're inside that loop) — a free-form key a user
           // set to "TODO" as their own note is a different key entirely
           // and is never inspected here.
-          findings.push(finding('L02-frontmatter-types', 'error', DERIVABLE_STRING_KEYS.has(field.key), wikiRelPath, null,
-            `"${field.key}" is set to the placeholder "TODO", which is not a real value`));
+          findings.push(finding('L02-frontmatter-types', 'error', DERIVABLE_STRING_KEYS.has(field.key),
+            wikiRelPath, null,
+            `"${field.key}" is set to the placeholder "TODO", which is not a real value`,
+            { key: field.key, fieldType: field.type, todoPlaceholder: true }));
         }
         break;
       case 'number':
         if (typeof val !== 'number' || isNaN(val)) {
-          findings.push(finding('L02-frontmatter-types', 'error', false, wikiRelPath, null,
-            `"${field.key}" must be a number, got ${JSON.stringify(val)}`));
+          findings.push(l02TypeFinding(wikiRelPath, field, false, 'a number', JSON.stringify(val)));
         }
         break;
       case 'array':
@@ -1182,8 +1205,7 @@ function checkL02(wikiRelPath, fm) {
           // rendered as list items, so it is reported for a human instead.
           const isNonEmptyMapping = val !== null && typeof val === 'object'
             && !Array.isArray(val) && Object.keys(val).length > 0;
-          findings.push(finding('L02-frontmatter-types', 'error', !isNonEmptyMapping, wikiRelPath, null,
-            `"${field.key}" must be an array, got ${typeof val}`));
+          findings.push(l02TypeFinding(wikiRelPath, field, !isNonEmptyMapping, 'an array', `${typeof val}`));
         }
         break;
       case 'iso-date':
@@ -1191,20 +1213,20 @@ function checkL02(wikiRelPath, fm) {
           // Only the TODO sentinel (written by the pre-fix fixL01) has a safe
           // derivation; any other malformed date is left for a human to fix.
           const fixableIsoDate = typeof val === 'string' && val.trim() === 'TODO';
-          findings.push(finding('L02-frontmatter-types', 'error', fixableIsoDate, wikiRelPath, null,
-            `"${field.key}" must be an ISO date (YYYY-MM-DD), got ${JSON.stringify(val)}`));
+          findings.push(l02TypeFinding(wikiRelPath, field, fixableIsoDate,
+            'an ISO date (YYYY-MM-DD)', JSON.stringify(val)));
         }
         break;
       case 'enum':
         if (field.values && !field.values.includes(val)) {
-          findings.push(finding('L02-frontmatter-types', 'error', false, wikiRelPath, null,
-            `"${field.key}" must be one of [${field.values.join(', ')}], got ${JSON.stringify(val)}`));
+          findings.push(l02TypeFinding(wikiRelPath, field, false,
+            `one of [${field.values.join(', ')}]`, JSON.stringify(val)));
         }
         break;
       case 'object':
         if (typeof val !== 'object' || val === null || Array.isArray(val)) {
-          findings.push(finding('L02-frontmatter-types', 'error', false, wikiRelPath, null,
-            `"${field.key}" must be an object, got ${Array.isArray(val) ? 'array' : typeof val}`));
+          findings.push(l02TypeFinding(wikiRelPath, field, false, 'an object',
+            Array.isArray(val) ? 'array' : `${typeof val}`));
         }
         break;
     }
@@ -1230,7 +1252,8 @@ function checkL02(wikiRelPath, fm) {
       const targetValid = targetPresent && Boolean(targetFieldDef) && isLegacyTargetValid(targetFieldDef.type, targetVal);
       const removable = targetValid && isLegacyValueEquivalent(targetFieldDef.type, fm[oldKey], targetVal);
       findings.push(finding('L02-frontmatter-types', 'warning', removable, wikiRelPath, null,
-        `Legacy frontmatter field "${oldKey}" was renamed to "${info.newKey}" in ${info.since}. Run /lumi-migrate-legacy to upgrade.`));
+        `Legacy frontmatter field "${oldKey}" was renamed to "${info.newKey}" in ${info.since}. Run /lumi-migrate-legacy to upgrade.`,
+        { legacyOldKey: oldKey, legacyNewKey: info.newKey }));
     }
   }
 
@@ -1793,10 +1816,9 @@ async function fixL01(absPath, wikiRelPath, content, l01findings) {
   const additions = [];
   for (const f of l01findings) {
     if (f.id !== 'L01-frontmatter-required') continue;
-    const m = f.message.match(/"([^"]+)"\s*\(type:\s*([^)]+)\)/);
-    if (!m) continue;
-    const key = m[1];
-    const fieldType = m[2].trim();
+    const key = f.key;
+    const fieldType = f.fieldType;
+    if (!key || !fieldType) continue;
     if (!isL01Fixable(entityType, { key, type: fieldType })) continue;
 
     let value;
@@ -1866,18 +1888,16 @@ async function fixL02(absPath, wikiRelPath, content, l02findings, edges, knownSl
   const entityType = entityTypeForPath(wikiRelPath);
   const fieldDefs = (entityType && REQUIRED_FRONTMATTER[entityType]) || [];
   const slugs = knownSlugs || new Set();
-  const LEGACY_MSG_RE = /^Legacy frontmatter field "([^"]+)" was renamed to "([^"]+)"/;
 
   const changes = [];   // { key, value } — repaired type-mismatch / TODO-iso-date fixes.
   const removals = [];  // { oldKey, newKey } — legacy fields safe to delete (Task 1).
 
   for (const f of l02findings) {
     if (f.id !== 'L02-frontmatter-types') continue;
-    if (LEGACY_MSG_RE.test(f.message)) continue; // handled in the removal pass below.
+    if (f.legacyOldKey) continue; // handled in the removal pass below.
 
-    const m = f.message.match(/^"([^"]+)"/);
-    if (!m) continue;
-    const key = m[1];
+    const key = f.key;
+    if (!key) continue;
     const fieldDef = fieldDefs.find(fd => fd.key === key);
     if (!fieldDef) continue;
     const val = fm[key];
@@ -1923,9 +1943,8 @@ async function fixL02(absPath, wikiRelPath, content, l02findings, edges, knownSl
   };
   for (const f of l02findings) {
     if (f.id !== 'L02-frontmatter-types') continue;
-    const m = f.message.match(LEGACY_MSG_RE);
-    if (!m) continue;
-    const [, oldKey, newKey] = m;
+    const { legacyOldKey: oldKey, legacyNewKey: newKey } = f;
+    if (!oldKey || !newKey) continue;
     const targetFieldDef = fieldDefs.find(fd => fd.key === newKey);
     if (!targetFieldDef) continue;
     const targetVal = effectiveValue(newKey);
@@ -2323,8 +2342,7 @@ async function applyFixes(findings, wikiRoot, edgesPath, indexPath, indexContent
         content = newContent;
         const fixedSet = new Set(fixedKeys);
         for (const f of l01findings) {
-          const km = f.message.match(/"([^"]+)"/);
-          if (!km || !fixedSet.has(km[1])) continue;
+          if (!f.key || !fixedSet.has(f.key)) continue;
           if (opts.dryRun) f.proposed_fix = preview;
           else f.fix_applied = true;
         }
@@ -2338,8 +2356,8 @@ async function applyFixes(findings, wikiRoot, edgesPath, indexPath, indexContent
         content = newContent;
         const fixedSet = new Set(fixedKeys);
         for (const f of l02findings) {
-          const km = f.message.match(/^"([^"]+)"/) || f.message.match(/^Legacy frontmatter field "([^"]+)"/);
-          if (!km || !fixedSet.has(km[1])) continue;
+          const key = f.key ?? f.legacyOldKey;
+          if (!key || !fixedSet.has(key)) continue;
           if (opts.dryRun) f.proposed_fix = preview;
           else f.fix_applied = true;
         }
@@ -2493,21 +2511,17 @@ function computeSuggestion(f) {
 
   if (f.id === 'L01-frontmatter-required') {
     if (f.fixable) return null; // --fix already handles this one.
-    const m = f.message.match(/"([^"]+)"\s*\(type:\s*([^)]+)\)/);
-    if (m) return `${m[1]}: ${m[2].trim()}, cannot be inferred — provide a value manually.`;
+    if (f.key && f.fieldType) return `${f.key}: ${f.fieldType}, cannot be inferred — provide a value manually.`;
   }
 
   if (f.id === 'L02-frontmatter-types') {
     if (f.fixable) return null; // --fix already handles this one (including a safe legacy-field removal).
-    const legacyMatch = f.message.match(/^Legacy frontmatter field "([^"]+)" was renamed to "([^"]+)"/);
-    if (legacyMatch) {
-      const [, oldKey, newKey] = legacyMatch;
+    if (f.legacyOldKey && f.legacyNewKey) {
+      const { legacyOldKey: oldKey, legacyNewKey: newKey } = f;
       return `"${oldKey}" survives because "${newKey}" is missing, invalid, or disagrees with it — resolve "${newKey}" by hand, then re-run --fix to drop "${oldKey}".`;
     }
-    const todoMatch = f.message.match(/^"([^"]+)" is set to the placeholder "TODO"/);
-    if (todoMatch) return `${todoMatch[1]}: currently "TODO" — no automatic derivation exists for this field; provide a real value manually.`;
-    const m = f.message.match(/^"([^"]+)"\s+must be ([^,]+),/);
-    if (m) return `${m[1]}: expected ${m[2].trim()}, cannot be safely inferred — provide a value manually.`;
+    if (f.todoPlaceholder) return `${f.key}: currently "TODO" — no automatic derivation exists for this field; provide a real value manually.`;
+    if (f.key && f.expected) return `${f.key}: expected ${f.expected}, cannot be safely inferred — provide a value manually.`;
   }
 
   if (f.id === 'L05-broken-wikilink') {
@@ -2610,12 +2624,17 @@ function reportJson(findings, scannedFiles, opts = {}) {
   const infos = findings.filter(f => f.severity === 'info').length;
   const fixes = findings.filter(f => f.fix_applied).length;
 
-  // Strip internal-only fields (candidates/brokenSlug/suppressedRepair — set by
-  // checkL05 for fixL05's and computeSuggestion's own use) from the public
-  // shape; re-add `candidates` and the new `suggestion` key only when
-  // --suggest was requested.
+  // Strip internal-only fields from the public shape: candidates/brokenSlug/
+  // suppressedRepair (checkL05, for fixL05 and computeSuggestion) and
+  // key/fieldType/expected/todoPlaceholder/legacyOldKey/legacyNewKey (checkL01
+  // and checkL02, for their fixers and computeSuggestion). `candidates` and
+  // the `suggestion` key are re-added only when --suggest was requested.
   const outputFindings = findings.map(f => {
-    const { candidates, brokenSlug, suppressedRepair, ...rest } = f;
+    const {
+      candidates, brokenSlug, suppressedRepair,
+      key, fieldType, expected, todoPlaceholder, legacyOldKey, legacyNewKey,
+      ...rest
+    } = f;
     if (opts.suggest) {
       const suggestion = computeSuggestion(f);
       if (suggestion) rest.suggestion = suggestion;

--- a/src/scripts/lint.mjs
+++ b/src/scripts/lint.mjs
@@ -369,38 +369,6 @@ function roundTripsAsFrontmatter(key, value) {
 }
 
 /**
- * Split raw file content into the frontmatter text (no `---` delimiters)
- * and the tail (starting with the newline before the closing `---`,
- * through end of file). Returns null when there is no parseable
- * frontmatter block. Shared by fixL01 and fixL02 so both fixers rewrite
- * the frontmatter block the same way.
- * @param {string} content
- * @returns {{ fmText: string, tail: string }|null}
- */
-function splitRawFrontmatter(content) {
-  if (!content.startsWith('---')) return null;
-  const rest = content.slice(3);
-  const nlIdx = rest.indexOf('\n');
-  if (nlIdx === -1) return null;
-  // Mirror parseFrontmatter's rule for where the block starts, exactly. It
-  // treats a non-empty first line as part of the frontmatter when it is a YAML
-  // key line, and rejects the block outright otherwise. Diverging here makes
-  // the two disagree about which keys exist: unconditionally skipping the first
-  // line drops `---id: x` on rewrite, and accepting a block parseFrontmatter
-  // rejects leaves fixL01 with an empty view of the frontmatter, so it appends
-  // a second copy of every key that was already there.
-  const afterDash = rest.slice(0, nlIdx).trim();
-  if (afterDash !== '' && !/^[a-zA-Z_][a-zA-Z0-9_]*\s*:/.test(afterDash)) return null;
-  const bodyStart = rest.indexOf('\n---');
-  if (bodyStart === -1) return null;
-  const fmText = afterDash !== ''
-    ? rest.slice(0, bodyStart)
-    : rest.slice(nlIdx + 1, bodyStart);
-  const tail = rest.slice(bodyStart); // "\n---\n<body>"
-  return { fmText, tail };
-}
-
-/**
  * Replace the line(s) for an existing top-level frontmatter key (the key's
  * own line plus any indented continuation lines it owns — a block list or
  * block mapping) with new rendered line(s). Used by fixL02 to repair a
@@ -909,7 +877,7 @@ function safejoin(base, ...parts) {
  * Returns { data: object, body: string, end: number } or null if no frontmatter.
  * Supports string, number, array (- item per line), and inline YAML arrays.
  * @param {string} content
- * @returns {{ data: Record<string,unknown>, body: string, fmLines: string[] }|null}
+ * @returns {{ data: Record<string,unknown>, body: string, fmText: string, tail: string }|null}
  */
 function parseFrontmatter(content) {
   if (!content.startsWith('---')) return null;
@@ -928,10 +896,10 @@ function parseFrontmatter(content) {
     ? rest.slice(0, bodyStart)
     : rest.slice(nlIdx + 1, bodyStart);
   const body = rest.slice(bodyStart + 4);
+  const tail = rest.slice(bodyStart); // "\n---\n<body>" — what the fixers rewrite around.
 
   const data = {};
   const lines = fmText.split('\n');
-  const fmLines = lines;
   let i = 0;
   while (i < lines.length) {
     const line = lines[i];
@@ -990,7 +958,7 @@ function parseFrontmatter(content) {
     i++;
   }
 
-  return { data, body, fmLines };
+  return { data, body, fmText, tail };
 }
 
 /**
@@ -1798,13 +1766,11 @@ function checkL17(edges, knownSlugs) {
  * @returns {Promise<{ newContent: string, preview: string }>}
  */
 async function fixL01(absPath, wikiRelPath, content, l01findings) {
-  const split = splitRawFrontmatter(content);
   const parsed = parseFrontmatter(content);
-  // Both parsers must agree the block is readable. If parseFrontmatter cannot
-  // read it, we have no reliable view of which keys already exist, and
+  // No readable block means no reliable view of which keys already exist, and
   // appending would duplicate them.
-  if (!split || !parsed) return { newContent: content, preview: '', fixedKeys: [] };
-  const { fmText, tail } = split;
+  if (!parsed) return { newContent: content, preview: '', fixedKeys: [] };
+  const { fmText, tail } = parsed;
 
   const fm = parsed.data;
   const body = parsed.body;
@@ -1875,10 +1841,9 @@ async function fixL01(absPath, wikiRelPath, content, l01findings) {
  * @returns {Promise<{ newContent: string, preview: string }>}
  */
 async function fixL02(absPath, wikiRelPath, content, l02findings, edges, knownSlugs) {
-  const split = splitRawFrontmatter(content);
   const parsed = parseFrontmatter(content);
-  // Same agreement requirement as fixL01 — see the comment there.
-  if (!split || !parsed) return { newContent: content, preview: '', fixedKeys: [] };
+  // Same readability requirement as fixL01 — see the comment there.
+  if (!parsed) return { newContent: content, preview: '', fixedKeys: [] };
 
   const fm = parsed.data;
   const body = parsed.body;
@@ -1953,14 +1918,14 @@ async function fixL02(absPath, wikiRelPath, content, l02findings, edges, knownSl
 
   if (changes.length === 0 && removals.length === 0) return { newContent: content, preview: '', fixedKeys: [] };
 
-  let fmText = split.fmText;
+  let fmText = parsed.fmText;
   for (const { key, value } of changes) {
     fmText = replaceFrontmatterKeyLines(fmText, key, renderYamlLine(key, value));
   }
   for (const { oldKey } of removals) {
     fmText = removeFrontmatterKeyLines(fmText, oldKey);
   }
-  const newContent = `---\n${fmText}${split.tail}`;
+  const newContent = `---\n${fmText}${parsed.tail}`;
   const preview = [
     ...changes.map(({ key, value }) => `~ ${renderYamlLine(key, value)}`),
     ...removals.map(({ oldKey }) => `- ${oldKey} (redundant with its already-valid replacement)`),

--- a/src/scripts/lint.mjs
+++ b/src/scripts/lint.mjs
@@ -44,23 +44,23 @@
  * ─────────────────────────────────────────────────────────────────────────────
  */
 
-import { readFile, writeFile, rename, mkdir, readdir, stat, access, unlink } from 'node:fs/promises';
+import { readFile, rename, readdir, stat, access } from 'node:fs/promises';
 import { constants as fsConstants } from 'node:fs';
 import { join, basename, dirname, relative, normalize, resolve } from 'node:path';
-import { randomBytes } from 'node:crypto';
 
 import {
   SCHEMA_VERSION,
   ENTITY_DIRS,
   EDGE_TYPES,
   REQUIRED_FRONTMATTER,
-  EXEMPTION_GLOBS,
 } from './schemas.mjs';
 import {
   EXTERNAL_ID_NAMESPACES,
   normalizeExternalId,
   parseUrlToExternalIds,
 } from './external-ids.mjs';
+import { atomicWrite } from './lib/fsx.mjs';
+import { isExempt } from './lib/globs.mjs';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // CONSTANTS
@@ -849,25 +849,6 @@ function err(text) { return useColor() ? `\x1b[31m[ERR]\x1b[0m ${text}` : `[ERR]
 function info(text) { return useColor() ? `\x1b[36m[INFO]\x1b[0m ${text}` : `[INFO] ${text}`; }
 
 /**
- * Atomic write: write to a temp file, fsync via close, then rename into place.
- * @param {string} filePath  Absolute destination path.
- * @param {string} content   UTF-8 content to write.
- */
-async function atomicWrite(filePath, content) {
-  const dir = dirname(filePath);
-  await mkdir(dir, { recursive: true });
-  const tmp = join(dir, `.lint-tmp-${randomBytes(6).toString('hex')}`);
-  try {
-    await writeFile(tmp, content, { encoding: 'utf8', flag: 'w' });
-    await rename(tmp, filePath);
-  } catch (e) {
-    // Best-effort cleanup of tmp on failure.
-    await unlink(tmp).catch(() => {});
-    throw e;
-  }
-}
-
-/**
  * Recursively walk a directory, yielding absolute paths of all .md files.
  * @param {string} dir
  * @returns {Promise<string[]>}
@@ -1041,20 +1022,6 @@ async function parseEdgesJsonl(edgesPath) {
  * @param {string} target
  * @returns {boolean}
  */
-function isExempt(target) {
-  for (const glob of EXEMPTION_GLOBS) {
-    if (glob === '*://*') {
-      if (/^[a-z][a-z0-9+\-.]*:\/\//i.test(target)) return true;
-    } else if (glob.endsWith('/**')) {
-      const prefix = glob.slice(0, -3);
-      if (target === prefix || target.startsWith(prefix + '/')) return true;
-    } else if (target === glob) {
-      return true;
-    }
-  }
-  return false;
-}
-
 /**
  * Determine entity type dir for a wiki-relative file path.
  * e.g. "sources/lora.md" => "sources"

--- a/src/scripts/lint.mjs
+++ b/src/scripts/lint.mjs
@@ -47,7 +47,6 @@
 import { readFile, writeFile, rename, mkdir, readdir, stat, access, unlink } from 'node:fs/promises';
 import { constants as fsConstants } from 'node:fs';
 import { join, basename, dirname, relative, normalize, resolve } from 'node:path';
-import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 
 import {
@@ -55,7 +54,6 @@ import {
   ENTITY_DIRS,
   EDGE_TYPES,
   REQUIRED_FRONTMATTER,
-  ENUMS,
   EXEMPTION_GLOBS,
 } from './schemas.mjs';
 import {
@@ -1821,9 +1819,8 @@ async function fixL01(absPath, wikiRelPath, content, l01findings) {
   const { fmText, tail } = split;
 
   const fm = parsed.data;
-  const body = parsed ? parsed.body : '';
+  const body = parsed.body;
   const entityType = entityTypeForPath(wikiRelPath);
-  const fieldDefs = (entityType && REQUIRED_FRONTMATTER[entityType]) || [];
 
   const additions = [];
   for (const f of l01findings) {
@@ -1897,7 +1894,7 @@ async function fixL02(absPath, wikiRelPath, content, l02findings, edges, knownSl
   if (!split || !parsed) return { newContent: content, preview: '', fixedKeys: [] };
 
   const fm = parsed.data;
-  const body = parsed ? parsed.body : '';
+  const body = parsed.body;
   const entityType = entityTypeForPath(wikiRelPath);
   const fieldDefs = (entityType && REQUIRED_FRONTMATTER[entityType]) || [];
   const slugs = knownSlugs || new Set();
@@ -2280,10 +2277,8 @@ async function runLint(projectRoot, opts) {
   allFindings.push(...checkL08(edges));
   allFindings.push(...checkL17(edges, knownSlugs));
 
-  if (indexContent !== undefined) {
-    const indexEntityFiles = entityFiles.filter(f => !isIndexExempt(f));
-    allFindings.push(...checkL09(indexPath, indexContent, indexEntityFiles));
-  }
+  const indexEntityFiles = entityFiles.filter(f => !isIndexExempt(f));
+  allFindings.push(...checkL09(indexPath, indexContent, indexEntityFiles));
 
   // L10: collect all foundation frontmatters in one pass, then check for alias conflicts.
   {

--- a/src/scripts/lint.mjs
+++ b/src/scripts/lint.mjs
@@ -674,13 +674,18 @@ const ARRAY_FIELD_TARGET_DIR = {
  * @param {Set<string>} knownSlugs
  * @returns {Map<string,string[]>}
  */
+const _basenameIndexCache = new WeakMap();
+
 function buildBasenameIndex(knownSlugs) {
+  const cached = _basenameIndexCache.get(knownSlugs);
+  if (cached) return cached;
   const index = new Map();
   for (const slug of knownSlugs) {
     const base = basename(slug);
     if (!index.has(base)) index.set(base, []);
     index.get(base).push(slug);
   }
+  _basenameIndexCache.set(knownSlugs, index);
   return index;
 }
 
@@ -760,9 +765,10 @@ function reconstructArrayFromBody(field, selfSlug, body, knownSlugs) {
   const results = new Set();
   const lines = body.split('\n');
   const inFence = fencedCodeLines(lines);
+  const re = new RegExp(WIKILINK_RE.source, 'g');
   for (let li = 0; li < lines.length; li++) {
     if (inFence[li]) continue; // sample syntax in a code block is not a relationship.
-    const re = new RegExp(WIKILINK_RE.source, 'g');
+    re.lastIndex = 0;
     let m;
     while ((m = re.exec(lines[li])) !== null) {
       const resolved = resolveWikilinkTarget(m[1], knownSlugs, basenameIndex);
@@ -1314,12 +1320,13 @@ function checkL05(wikiRelPath, rawContent, knownSlugs) {
 
   const lines = rawContent.split('\n');
   const inFence = fencedCodeLines(lines);
+  const lineRe = new RegExp(WIKILINK_RE.source, 'g');
   for (let li = 0; li < lines.length; li++) {
     // A `[[...]]` inside a fenced code block is sample syntax, not a link.
     // Reporting it would also be unfixable-by-design: rewriting it corrupts
     // the very example the author wrote, so the finding could never clear.
     if (inFence[li]) continue;
-    const lineRe = new RegExp(WIKILINK_RE.source, 'g');
+    lineRe.lastIndex = 0;
     while ((match = lineRe.exec(lines[li])) !== null) {
       const slug = match[1].trim();
       if (!knownSlugs.has(slug)) {
@@ -2221,6 +2228,7 @@ async function runLint(projectRoot, opts) {
   // Build wikilink maps.
   const outboundMap = new Map(); // wikiRelPath -> Set<slug>
   const inboundSet = new Set();  // wikiRelPath values that have inbound links
+  const linkRe = new RegExp(WIKILINK_RE.source, 'g');
 
   for (const wikiRelPath of allWikiRel) {
     const abs = safejoin(wikiRoot, wikiRelPath);
@@ -2228,9 +2236,9 @@ async function runLint(projectRoot, opts) {
     const slugs = new Set();
     const lines = content.split('\n');
     for (const line of lines) {
-      const re = new RegExp(WIKILINK_RE.source, 'g');
+      linkRe.lastIndex = 0;
       let m;
-      while ((m = re.exec(line)) !== null) {
+      while ((m = linkRe.exec(line)) !== null) {
         const slug = m[1].trim();
         slugs.add(slug);
         // Mark as having inbound link if slug resolves to a known file.

--- a/src/scripts/lint.mjs
+++ b/src/scripts/lint.mjs
@@ -2226,13 +2226,30 @@ async function runLint(projectRoot, opts) {
   const knownSlugs = new Set(allWikiRel.map(f => f.replace(/\.md$/, '')));
 
   // Build wikilink maps.
+  // One snapshot of every scanned file, shared by the link scan, the per-file
+  // checks and the foundations pass below. Nothing writes to the wiki until
+  // applyFixes runs, so the three passes cannot observe different bytes; the
+  // fixers deliberately re-read, because by then earlier fixes have landed.
+  const contentCache = new Map();
+  {
+    const POOL = 32;
+    let next = 0;
+    await Promise.all(
+      Array.from({ length: Math.min(POOL, allWikiRel.length) }, async () => {
+        for (let i = next++; i < allWikiRel.length; i = next++) {
+          const rel = allWikiRel[i];
+          contentCache.set(rel, await readFile(safejoin(wikiRoot, rel), 'utf8'));
+        }
+      }),
+    );
+  }
+
   const outboundMap = new Map(); // wikiRelPath -> Set<slug>
   const inboundSet = new Set();  // wikiRelPath values that have inbound links
   const linkRe = new RegExp(WIKILINK_RE.source, 'g');
 
   for (const wikiRelPath of allWikiRel) {
-    const abs = safejoin(wikiRoot, wikiRelPath);
-    const content = await readFile(abs, 'utf8');
+    const content = contentCache.get(wikiRelPath);
     const slugs = new Set();
     const lines = content.split('\n');
     for (const line of lines) {
@@ -2263,8 +2280,7 @@ async function runLint(projectRoot, opts) {
   const allFindings = [];
 
   for (const wikiRelPath of allWikiRel) {
-    const abs = safejoin(wikiRoot, wikiRelPath);
-    const content = await readFile(abs, 'utf8');
+    const content = contentCache.get(wikiRelPath);
     const parsed = parseFrontmatter(content);
     const fm = parsed ? parsed.data : {};
 
@@ -2293,8 +2309,7 @@ async function runLint(projectRoot, opts) {
     const foundationEntries = [];
     for (const wikiRelPath of entityFiles) {
       if (!wikiRelPath.startsWith('foundations/')) continue;
-      const abs = safejoin(wikiRoot, wikiRelPath);
-      const content = await readFile(abs, 'utf8');
+      const content = contentCache.get(wikiRelPath);
       const parsed = parseFrontmatter(content);
       foundationEntries.push({ wikiRelPath, fm: parsed ? parsed.data : {} });
     }

--- a/src/scripts/lint.mjs
+++ b/src/scripts/lint.mjs
@@ -52,6 +52,8 @@ import {
   SCHEMA_VERSION,
   ENTITY_DIRS,
   REQUIRED_FRONTMATTER,
+  EDGE_CONFIDENCE,
+  LEGACY_ENUM_DEFAULTS,
 } from './schemas.mjs';
 import {
   EXTERNAL_ID_NAMESPACES,
@@ -125,17 +127,6 @@ const LEGACY_RENAMED_FIELDS = {
   },
 };
 
-/**
- * Defaults for enum fields that have a known-safe fallback value.
- * Mirrors `LEGACY_DEFAULTS` in wiki.mjs (see wiki.mjs's `migrateLegacyDefaults`
- * for the canonical original) — duplicated here, not imported, so lint.mjs
- * stays decoupled from wiki.mjs. Keep the two in sync by hand if either
- * changes.
- */
-const LINT_LEGACY_DEFAULTS = {
-  sources: { provenance: 'missing', confidence: 'unverified' },
-  concepts: { confidence: 'unverified' },
-};
 
 /**
  * Entity dirs whose `id` is the FULL wiki-relative path (dir included),
@@ -296,13 +287,17 @@ async function deriveIsoDateValue(fm, absPath) {
 }
 
 /**
- * Quote a scalar string for frontmatter output only when required —
- * mirrors wiki.mjs's `quoteIfNeeded` (not imported; see LINT_LEGACY_DEFAULTS
- * comment for why the modules stay decoupled). Only used for top-level
- * scalar lines; block-list items are never quoted because lint.mjs's own
- * `parseFrontmatter` does not strip quotes from list items (see its
- * `listM` branch), so a quoted list item would round-trip as a literal
- * quoted string instead of the bare value.
+ * Quote a scalar string for frontmatter output only when required.
+ *
+ * Still separate from wiki.mjs's `quoteIfNeeded`, and not for decoupling —
+ * the two modules already share lib/. They genuinely serialise different
+ * dialects today: this one is only used for top-level scalar lines, and
+ * block-list items are never quoted because lint.mjs's own
+ * `parseFrontmatter` does not strip quotes from list items (see its `listM`
+ * branch), so a quoted list item would round-trip as a literal quoted string
+ * instead of the bare value. wiki.mjs's parser does strip them. Unifying the
+ * pair means unifying the two parsers first — a behaviour change for `--fix`,
+ * not a refactor. Note this copy handles `val === ''` and wiki.mjs's does not.
  * @param {string} val
  * @returns {string}
  */
@@ -1103,7 +1098,7 @@ function l02TypeFinding(wikiRelPath, field, fixable, expected, got) {
  * this must stay a pure, check-time decision):
  *   - array / object / iso-date: always derivable ([]/{}/mtime-or-legacy-date).
  *   - string: only `id`, `type`, `title` have a defined derivation rule.
- *   - enum: only if LINT_LEGACY_DEFAULTS has a safe default for this key.
+ *   - enum: only if LEGACY_ENUM_DEFAULTS has a safe default for this key.
  *   - number, and any other case: never — a wrong guess is worse than a
  *     loud "missing" finding.
  * @param {string} entityType
@@ -1119,7 +1114,7 @@ function isL01Fixable(entityType, field) {
     case 'string':
       return DERIVABLE_STRING_KEYS.has(field.key);
     case 'enum':
-      return Boolean(LINT_LEGACY_DEFAULTS[entityType] && field.key in LINT_LEGACY_DEFAULTS[entityType]);
+      return Boolean(LEGACY_ENUM_DEFAULTS[entityType] && field.key in LEGACY_ENUM_DEFAULTS[entityType]);
     case 'number':
     default:
       return false;
@@ -1446,8 +1441,7 @@ function checkL08(edges) {
     const edgeType = edgeTypeByName(edge.type);
     if (!edgeType || !edgeType.confidenceRequired) continue;
 
-    const validConfidence = ['high', 'medium', 'low'];
-    if (!edge.confidence || !validConfidence.includes(edge.confidence)) {
+    if (!edge.confidence || !EDGE_CONFIDENCE.includes(edge.confidence)) {
       findings.push(finding(
         'L08-edge-confidence-required', 'error', false,
         edge.from, null,
@@ -1790,7 +1784,7 @@ function checkL17(edges, knownSlugs) {
  *   - string `id` -> legacy `slug` if present, else derived from path
  *   - string `type` -> derived from the entity directory
  *   - string `title` -> first H1 in the body, else Title-Cased basename
- *   - enum -> only if LINT_LEGACY_DEFAULTS has a safe default
+ *   - enum -> only if LEGACY_ENUM_DEFAULTS has a safe default
  *   - number, and any other case -> NOT written; the finding stays unfixed
  *     (see isL01Fixable, which decided `finding.fixable` at check time —
  *     this fixer's per-key decision mirrors it exactly).
@@ -1832,7 +1826,7 @@ async function fixL01(absPath, wikiRelPath, content, l01findings) {
         else if (key === 'title') value = deriveTitleFromContent(wikiRelPath, body);
         break;
       case 'enum': {
-        const defaults = LINT_LEGACY_DEFAULTS[entityType];
+        const defaults = LEGACY_ENUM_DEFAULTS[entityType];
         value = defaults ? defaults[key] : undefined;
         break;
       }

--- a/src/scripts/lint.test.mjs
+++ b/src/scripts/lint.test.mjs
@@ -873,7 +873,7 @@ describe('L09 index-stale', () => {
 
 describe('fixL01', () => {
   function fakeL01(key, type) {
-    return [{ id: 'L01-frontmatter-required', message: `Missing required frontmatter key: "${key}" (type: ${type})` }];
+    return [{ id: 'L01-frontmatter-required', key, fieldType: type, message: `Missing required frontmatter key: "${key}" (type: ${type})` }];
   }
 
   function todayYmd() {
@@ -993,7 +993,7 @@ describe('fixL01', () => {
 describe('fixL02', () => {
   test('string where array expected: wraps losslessly', async () => {
     const content = `---\nid: my-concept\ntitle: My Concept\ntype: concept\ncreated: 2026-01-01\nupdated: 2026-01-01\nkey_sources: "[[sources/foo]]"\nrelated_concepts: []\n---\nbody`;
-    const findings = [{ id: 'L02-frontmatter-types', message: '"key_sources" must be an array, got string' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'key_sources', fieldType: 'array', expected: 'an array', message: '"key_sources" must be an array, got string' }];
     const { newContent } = await fixL02('/tmp/fake/concepts/my-concept.md', 'concepts/my-concept.md', content, findings, []);
     assert.ok(newContent.includes('key_sources:\n  - [[sources/foo]]'), newContent);
   });
@@ -1004,7 +1004,7 @@ describe('fixL02', () => {
       { from: 'concepts/my-concept', to: 'sources/paper-a', type: 'introduced_in' },
       { from: 'sources/paper-b', to: 'concepts/my-concept', type: 'uses_concept' },
     ];
-    const findings = [{ id: 'L02-frontmatter-types', message: '"key_sources" must be an array, got string' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'key_sources', fieldType: 'array', expected: 'an array', message: '"key_sources" must be an array, got string' }];
     const { newContent } = await fixL02('/tmp/fake/concepts/my-concept.md', 'concepts/my-concept.md', content, findings, edges);
     assert.ok(newContent.includes('[[sources/paper-a]]'));
     assert.ok(newContent.includes('[[sources/paper-b]]'));
@@ -1016,7 +1016,7 @@ describe('fixL02', () => {
       { from: 'concepts/concept-a', to: 'concepts/concept-b', type: 'related_to' }, // self is "from"
       { from: 'concepts/concept-c', to: 'concepts/concept-a', type: 'related_to' }, // self is "to" (alpha-sorted)
     ];
-    const findings = [{ id: 'L02-frontmatter-types', message: '"related_concepts" must be an array, got string' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'related_concepts', fieldType: 'array', expected: 'an array', message: '"related_concepts" must be an array, got string' }];
     const { newContent } = await fixL02('/tmp/fake/concepts/concept-a.md', 'concepts/concept-a.md', content, findings, edges);
     assert.ok(newContent.includes('[[concepts/concept-b]]'));
     assert.ok(newContent.includes('[[concepts/concept-c]]'));
@@ -1028,7 +1028,7 @@ describe('fixL02', () => {
       { from: 'people/alice', to: 'sources/paper-a', type: 'authored' },
       { from: 'sources/paper-b', to: 'people/alice', type: 'authored_by' },
     ];
-    const findings = [{ id: 'L02-frontmatter-types', message: '"key_sources" must be an array, got string' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'key_sources', fieldType: 'array', expected: 'an array', message: '"key_sources" must be an array, got string' }];
     const { newContent } = await fixL02('/tmp/fake/people/alice.md', 'people/alice.md', content, findings, edges);
     assert.ok(newContent.includes('[[sources/paper-a]]'));
     assert.ok(newContent.includes('[[sources/paper-b]]'));
@@ -1040,7 +1040,7 @@ describe('fixL02', () => {
       { from: 'topics/my-topic', to: 'sources/paper-a', type: 'includes_source' },
       { from: 'sources/paper-b', to: 'topics/my-topic', type: 'included_in_topic' },
     ];
-    const findings = [{ id: 'L02-frontmatter-types', message: '"key_sources" must be an array, got string' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'key_sources', fieldType: 'array', expected: 'an array', message: '"key_sources" must be an array, got string' }];
     const { newContent } = await fixL02('/tmp/fake/topics/my-topic.md', 'topics/my-topic.md', content, findings, edges);
     assert.ok(newContent.includes('[[sources/paper-a]]'));
     assert.ok(newContent.includes('[[sources/paper-b]]'));
@@ -1051,8 +1051,8 @@ describe('fixL02', () => {
     // Even with a matching-looking edge present, reflections must stay [].
     const edges = [{ from: 'reflections/reflection-x', to: 'concepts/some-concept', type: 'related_to' }];
     const findings = [
-      { id: 'L02-frontmatter-types', message: '"related_concepts" must be an array, got string' },
-      { id: 'L02-frontmatter-types', message: '"related_sources" must be an array, got string' },
+      { id: 'L02-frontmatter-types', key: 'related_concepts', fieldType: 'array', expected: 'an array', message: '"related_concepts" must be an array, got string' },
+      { id: 'L02-frontmatter-types', key: 'related_sources', fieldType: 'array', expected: 'an array', message: '"related_sources" must be an array, got string' },
     ];
     const { newContent } = await fixL02('/tmp/fake/reflections/reflection-x.md', 'reflections/reflection-x.md', content, findings, edges);
     assert.ok(newContent.includes('related_concepts: []'));
@@ -1061,14 +1061,14 @@ describe('fixL02', () => {
 
   test('no matching edges: falls back to []', async () => {
     const content = `---\nid: my-concept\ntitle: My Concept\ntype: concept\ncreated: 2026-01-01\nupdated: 2026-01-01\nkey_sources: TODO\nrelated_concepts: []\n---\nbody`;
-    const findings = [{ id: 'L02-frontmatter-types', message: '"key_sources" must be an array, got string' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'key_sources', fieldType: 'array', expected: 'an array', message: '"key_sources" must be an array, got string' }];
     const { newContent } = await fixL02('/tmp/fake/concepts/my-concept.md', 'concepts/my-concept.md', content, findings, []);
     assert.ok(newContent.includes('key_sources: []'));
   });
 
   test('TODO in iso-date: same derivation as fixL01 (legacy date_added)', async () => {
     const content = `---\nid: x\ntitle: X\ntype: source\ncreated: TODO\nupdated: 2026-01-01\ndate_added: 2019-09-09\nauthors: []\nyear: 2024\nimportance: 3\nprovenance: replayable\n---\nbody`;
-    const findings = [{ id: 'L02-frontmatter-types', message: '"created" must be an ISO date (YYYY-MM-DD), got "TODO"' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'created', fieldType: 'iso-date', expected: 'an ISO date (YYYY-MM-DD)', message: '"created" must be an ISO date (YYYY-MM-DD), got "TODO"' }];
     const { newContent } = await fixL02('/tmp/fake/sources/x.md', 'sources/x.md', content, findings, []);
     assert.ok(newContent.includes('created: 2019-09-09'));
   });
@@ -1076,8 +1076,8 @@ describe('fixL02', () => {
   test('TODO in number/enum: left unchanged, not repairable', async () => {
     const content = `---\nid: x\ntitle: X\ntype: source\ncreated: 2026-01-01\nupdated: 2026-01-01\nauthors: []\nyear: TODO\nimportance: TODO\nprovenance: replayable\n---\nbody`;
     const findings = [
-      { id: 'L02-frontmatter-types', message: '"year" must be a number, got "TODO"' },
-      { id: 'L02-frontmatter-types', message: '"importance" must be one of [1, 2, 3, 4, 5], got "TODO"' },
+      { id: 'L02-frontmatter-types', key: 'year', fieldType: 'number', expected: 'a number', message: '"year" must be a number, got "TODO"' },
+      { id: 'L02-frontmatter-types', key: 'importance', fieldType: 'enum', expected: 'one of [1, 2, 3, 4, 5]', message: '"importance" must be one of [1, 2, 3, 4, 5], got "TODO"' },
     ];
     const { newContent } = await fixL02('/tmp/fake/sources/x.md', 'sources/x.md', content, findings, []);
     assert.equal(newContent, content);
@@ -1089,7 +1089,7 @@ describe('fixL02', () => {
 
   test('TODO in "id" with no legacy "slug": derives from the file path', async () => {
     const content = `---\nid: TODO\ntitle: X\ntype: source\ncreated: 2026-01-01\nupdated: 2026-01-01\nauthors: []\nyear: 2026\nimportance: 3\nprovenance: replayable\n---\nbody`;
-    const findings = [{ id: 'L02-frontmatter-types', message: '"id" is set to the placeholder "TODO", which is not a real value' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'id', fieldType: 'string', todoPlaceholder: true, message: '"id" is set to the placeholder "TODO", which is not a real value' }];
     const { newContent, fixedKeys } = await fixL02('/tmp/fake/sources/my-paper.md', 'sources/my-paper.md', content, findings, []);
     assert.ok(newContent.includes('id: my-paper'), `expected id derived from path, got:\n${newContent}`);
     assert.deepEqual(fixedKeys, ['id']);
@@ -1097,7 +1097,7 @@ describe('fixL02', () => {
 
   test('TODO in "id" WITH legacy "slug" present: derives "id" from "slug" (lossless recovery)', async () => {
     const content = `---\nid: TODO\ntitle: X\ntype: source\ncreated: 2026-01-01\nupdated: 2026-01-01\nslug: real-value\nauthors: []\nyear: 2026\nimportance: 3\nprovenance: replayable\n---\nbody`;
-    const findings = [{ id: 'L02-frontmatter-types', message: '"id" is set to the placeholder "TODO", which is not a real value' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'id', fieldType: 'string', todoPlaceholder: true, message: '"id" is set to the placeholder "TODO", which is not a real value' }];
     const { newContent, fixedKeys } = await fixL02('/tmp/fake/sources/my-paper.md', 'sources/my-paper.md', content, findings, []);
     assert.ok(newContent.includes('id: real-value'), `expected id derived from slug, got:\n${newContent}`);
     assert.deepEqual(fixedKeys, ['id']);
@@ -1105,7 +1105,7 @@ describe('fixL02', () => {
 
   test('TODO in "type": derives from the entity directory', async () => {
     const content = `---\nid: x\ntitle: X\ntype: TODO\ncreated: 2026-01-01\nupdated: 2026-01-01\nauthors: []\nyear: 2026\nimportance: 3\nprovenance: replayable\n---\nbody`;
-    const findings = [{ id: 'L02-frontmatter-types', message: '"type" is set to the placeholder "TODO", which is not a real value' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'type', fieldType: 'string', todoPlaceholder: true, message: '"type" is set to the placeholder "TODO", which is not a real value' }];
     const { newContent, fixedKeys } = await fixL02('/tmp/fake/sources/x.md', 'sources/x.md', content, findings, []);
     assert.ok(newContent.includes('type: source'), `expected type derived from directory, got:\n${newContent}`);
     assert.deepEqual(fixedKeys, ['type']);
@@ -1113,7 +1113,7 @@ describe('fixL02', () => {
 
   test('TODO in "title": derives from the body H1', async () => {
     const content = `---\nid: x\ntitle: TODO\ntype: source\ncreated: 2026-01-01\nupdated: 2026-01-01\nauthors: []\nyear: 2026\nimportance: 3\nprovenance: replayable\n---\n# Real Title Here\n\nBody.`;
-    const findings = [{ id: 'L02-frontmatter-types', message: '"title" is set to the placeholder "TODO", which is not a real value' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'title', fieldType: 'string', todoPlaceholder: true, message: '"title" is set to the placeholder "TODO", which is not a real value' }];
     const { newContent, fixedKeys } = await fixL02('/tmp/fake/sources/x.md', 'sources/x.md', content, findings, []);
     assert.ok(newContent.includes('title: Real Title Here'), `expected title derived from H1, got:\n${newContent}`);
     assert.deepEqual(fixedKeys, ['title']);
@@ -1121,7 +1121,7 @@ describe('fixL02', () => {
 
   test('TODO in a non-derivable string field ("source" on readings): left unchanged', async () => {
     const content = `---\nid: readings/deep-work/01-focus\ntitle: Part 1\ntype: reading\ncreated: 2026-01-01\nupdated: 2026-01-01\nsource: TODO\npart: 1\n---\nbody`;
-    const findings = [{ id: 'L02-frontmatter-types', message: '"source" is set to the placeholder "TODO", which is not a real value' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'source', fieldType: 'string', todoPlaceholder: true, message: '"source" is set to the placeholder "TODO", which is not a real value' }];
     const { newContent, fixedKeys } = await fixL02('/tmp/fake/readings/deep-work/01-focus.md', 'readings/deep-work/01-focus.md', content, findings, []);
     assert.equal(newContent, content, '"source" has no derivation rule — must be left untouched');
     assert.deepEqual(fixedKeys, []);
@@ -1136,8 +1136,8 @@ describe('fixL02', () => {
     // equality already covers it).
     const content = `---\nid: TODO\ntitle: X\ntype: source\ncreated: 2026-01-01\nupdated: 2026-01-01\nslug: real-value\nauthors: []\nyear: 2026\nimportance: 3\nprovenance: replayable\n---\nBody.`;
     const findings = [
-      { id: 'L02-frontmatter-types', message: '"id" is set to the placeholder "TODO", which is not a real value' },
-      { id: 'L02-frontmatter-types', message: 'Legacy frontmatter field "slug" was renamed to "id" in v0.1. Run /lumi-migrate-legacy to upgrade.' },
+      { id: 'L02-frontmatter-types', key: 'id', fieldType: 'string', todoPlaceholder: true, message: '"id" is set to the placeholder "TODO", which is not a real value' },
+      { id: 'L02-frontmatter-types', legacyOldKey: 'slug', legacyNewKey: 'id', message: 'Legacy frontmatter field "slug" was renamed to "id" in v0.1. Run /lumi-migrate-legacy to upgrade.' },
     ];
     const { newContent, fixedKeys } = await fixL02('/tmp/fake/sources/x.md', 'sources/x.md', content, findings, []);
     assert.ok(newContent.includes('id: real-value'), `expected id recovered from slug, got:\n${newContent}`);
@@ -1157,7 +1157,7 @@ describe('fixL02', () => {
     // merged in.
     const edges = [{ from: 'concepts/concept-a', to: 'concepts/concept-b', type: 'related_to' }];
     const knownSlugs = new Set(['concepts/concept-a', 'concepts/concept-b', 'concepts/concept-z']);
-    const findings = [{ id: 'L02-frontmatter-types', message: '"related_concepts" must be an array, got string' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'related_concepts', fieldType: 'array', expected: 'an array', message: '"related_concepts" must be an array, got string' }];
     const { newContent } = await fixL02('/tmp/fake/concepts/concept-a.md', 'concepts/concept-a.md', content, findings, edges, knownSlugs);
     assert.ok(newContent.includes('[[concepts/concept-b]]'), 'graph-derived value must be used');
     assert.ok(!newContent.includes('[[concepts/concept-z]]'), 'body value must NOT be used when graph tier is non-empty');
@@ -1166,7 +1166,7 @@ describe('fixL02', () => {
   test('tier 2 (body) recovers related_concepts when graph has no related_to edges', async () => {
     const content = `---\nid: agent-taxonomy\ntitle: Agent Taxonomy\ntype: concept\ncreated: 2026-01-01\nupdated: 2026-01-01\nkey_sources: []\nrelated_concepts: TODO\n---\nSee [[concepts/tool-using-agents]] and [[concepts/planning-agents]].`;
     const knownSlugs = new Set(['concepts/agent-taxonomy', 'concepts/tool-using-agents', 'concepts/planning-agents']);
-    const findings = [{ id: 'L02-frontmatter-types', message: '"related_concepts" must be an array, got string' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'related_concepts', fieldType: 'array', expected: 'an array', message: '"related_concepts" must be an array, got string' }];
     const { newContent } = await fixL02('/tmp/fake/concepts/agent-taxonomy.md', 'concepts/agent-taxonomy.md', content, findings, [], knownSlugs);
     assert.ok(newContent.includes('[[concepts/tool-using-agents]]'));
     assert.ok(newContent.includes('[[concepts/planning-agents]]'));
@@ -1179,7 +1179,7 @@ describe('fixL02', () => {
     // unique-basename heuristic, without requiring L05 to run first.
     const content = `---\nid: agent-taxonomy\ntitle: Agent Taxonomy\ntype: concept\ncreated: 2026-01-01\nupdated: 2026-01-01\nkey_sources: []\nrelated_concepts: TODO\n---\nSee [[tool-using-agents]] for details.`;
     const knownSlugs = new Set(['concepts/agent-taxonomy', 'concepts/tool-using-agents']);
-    const findings = [{ id: 'L02-frontmatter-types', message: '"related_concepts" must be an array, got string' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'related_concepts', fieldType: 'array', expected: 'an array', message: '"related_concepts" must be an array, got string' }];
     const { newContent } = await fixL02('/tmp/fake/concepts/agent-taxonomy.md', 'concepts/agent-taxonomy.md', content, findings, [], knownSlugs);
     assert.ok(newContent.includes('[[concepts/tool-using-agents]]'));
   });
@@ -1187,7 +1187,7 @@ describe('fixL02', () => {
   test('tier 2 filters by entity type: a [[sources/x]] link must not land in related_concepts', async () => {
     const content = `---\nid: my-concept\ntitle: My Concept\ntype: concept\ncreated: 2026-01-01\nupdated: 2026-01-01\nkey_sources: []\nrelated_concepts: TODO\n---\nSee [[sources/some-paper]] for background.`;
     const knownSlugs = new Set(['concepts/my-concept', 'sources/some-paper']);
-    const findings = [{ id: 'L02-frontmatter-types', message: '"related_concepts" must be an array, got string' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'related_concepts', fieldType: 'array', expected: 'an array', message: '"related_concepts" must be an array, got string' }];
     const { newContent } = await fixL02('/tmp/fake/concepts/my-concept.md', 'concepts/my-concept.md', content, findings, [], knownSlugs);
     assert.ok(newContent.includes('related_concepts: []'), 'a sources/* link must not satisfy related_concepts');
   });
@@ -1196,7 +1196,7 @@ describe('fixL02', () => {
     const content = `---\nid: agent-taxonomy\ntitle: Agent Taxonomy\ntype: concept\ncreated: 2026-01-01\nupdated: 2026-01-01\nkey_sources: []\nrelated_concepts: TODO\n---\n` +
       `See [[concepts/agent-taxonomy]] (self), [[concepts/planning-agents|Planning Agents]], and again [[concepts/planning-agents]].`;
     const knownSlugs = new Set(['concepts/agent-taxonomy', 'concepts/planning-agents']);
-    const findings = [{ id: 'L02-frontmatter-types', message: '"related_concepts" must be an array, got string' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'related_concepts', fieldType: 'array', expected: 'an array', message: '"related_concepts" must be an array, got string' }];
     const { newContent } = await fixL02('/tmp/fake/concepts/agent-taxonomy.md', 'concepts/agent-taxonomy.md', content, findings, [], knownSlugs);
     assert.ok(!newContent.includes('[[concepts/agent-taxonomy]]\n  - [[concepts/agent-taxonomy]]'), 'sanity: not double-inserted');
     // Self-link excluded entirely.
@@ -1209,7 +1209,7 @@ describe('fixL02', () => {
   test('both tiers empty: falls back to [] (no graph edges, no resolvable body links)', async () => {
     const content = `---\nid: my-concept\ntitle: My Concept\ntype: concept\ncreated: 2026-01-01\nupdated: 2026-01-01\nkey_sources: []\nrelated_concepts: TODO\n---\nNo links here at all.`;
     const knownSlugs = new Set(['concepts/my-concept']);
-    const findings = [{ id: 'L02-frontmatter-types', message: '"related_concepts" must be an array, got string' }];
+    const findings = [{ id: 'L02-frontmatter-types', key: 'related_concepts', fieldType: 'array', expected: 'an array', message: '"related_concepts" must be an array, got string' }];
     const { newContent } = await fixL02('/tmp/fake/concepts/my-concept.md', 'concepts/my-concept.md', content, findings, [], knownSlugs);
     assert.ok(newContent.includes('related_concepts: []'));
   });
@@ -1218,8 +1218,8 @@ describe('fixL02', () => {
     const content = `---\nid: reflection-x\ntitle: X\ntype: reflection\ncreated: 2026-01-01\nupdated: 2026-01-01\nrelated_concepts: TODO\nrelated_sources: TODO\nevolution_count: 0\n---\nSee [[concepts/some-concept]] and [[sources/some-source]].`;
     const knownSlugs = new Set(['reflections/reflection-x', 'concepts/some-concept', 'sources/some-source']);
     const findings = [
-      { id: 'L02-frontmatter-types', message: '"related_concepts" must be an array, got string' },
-      { id: 'L02-frontmatter-types', message: '"related_sources" must be an array, got string' },
+      { id: 'L02-frontmatter-types', key: 'related_concepts', fieldType: 'array', expected: 'an array', message: '"related_concepts" must be an array, got string' },
+      { id: 'L02-frontmatter-types', key: 'related_sources', fieldType: 'array', expected: 'an array', message: '"related_sources" must be an array, got string' },
     ];
     const { newContent } = await fixL02('/tmp/fake/reflections/reflection-x.md', 'reflections/reflection-x.md', content, findings, [], knownSlugs);
     assert.ok(newContent.includes('related_concepts: []'));
@@ -1236,7 +1236,7 @@ describe('fixL02', () => {
 
   test('legacy "slug" -> "id": removes "slug" when it equals "id" verbatim', async () => {
     const content = `---\nid: test-source\ntitle: Test Source\ntype: source\ncreated: 2026-01-01\nupdated: 2026-01-01\nslug: test-source\nauthors: []\nyear: 2026\nimportance: 3\nprovenance: replayable\n---\nBody.`;
-    const findings = [{ id: 'L02-frontmatter-types', message: 'Legacy frontmatter field "slug" was renamed to "id" in v0.1. Run /lumi-migrate-legacy to upgrade.' }];
+    const findings = [{ id: 'L02-frontmatter-types', legacyOldKey: 'slug', legacyNewKey: 'id', message: 'Legacy frontmatter field "slug" was renamed to "id" in v0.1. Run /lumi-migrate-legacy to upgrade.' }];
     const { newContent, fixedKeys } = await fixL02('/tmp/fake/sources/test-source.md', 'sources/test-source.md', content, findings, []);
     assert.ok(!newContent.includes('slug:'), `expected "slug" removed, got:\n${newContent}`);
     assert.ok(newContent.includes('id: test-source'), 'id must be untouched');
@@ -1248,7 +1248,7 @@ describe('fixL02', () => {
     // runs in the real pipeline; simulate the case where, for whatever reason,
     // id is still missing at fixL02 time by omitting it entirely.
     const content = `---\ntitle: Test Source\ntype: source\ncreated: 2026-01-01\nupdated: 2026-01-01\nslug: test-source\nauthors: []\nyear: 2026\nimportance: 3\nprovenance: replayable\n---\nBody.`;
-    const findings = [{ id: 'L02-frontmatter-types', message: 'Legacy frontmatter field "slug" was renamed to "id" in v0.1. Run /lumi-migrate-legacy to upgrade.' }];
+    const findings = [{ id: 'L02-frontmatter-types', legacyOldKey: 'slug', legacyNewKey: 'id', message: 'Legacy frontmatter field "slug" was renamed to "id" in v0.1. Run /lumi-migrate-legacy to upgrade.' }];
     const { newContent, fixedKeys } = await fixL02('/tmp/fake/sources/test-source.md', 'sources/test-source.md', content, findings, []);
     assert.equal(newContent, content, 'id absent — slug is the only copy, must not be touched');
     assert.deepEqual(fixedKeys, []);
@@ -1256,7 +1256,7 @@ describe('fixL02', () => {
 
   test('legacy "date_added" -> "created": target ("created") INVALID — never removes "date_added"', async () => {
     const content = `---\nid: x\ntitle: X\ntype: source\ncreated: not-a-date\nupdated: 2026-01-01\ndate_added: 2020-01-01\nauthors: []\nyear: 2026\nimportance: 3\nprovenance: replayable\n---\nBody.`;
-    const findings = [{ id: 'L02-frontmatter-types', message: 'Legacy frontmatter field "date_added" was renamed to "created" in v0.1. Run /lumi-migrate-legacy to upgrade.' }];
+    const findings = [{ id: 'L02-frontmatter-types', legacyOldKey: 'date_added', legacyNewKey: 'created', message: 'Legacy frontmatter field "date_added" was renamed to "created" in v0.1. Run /lumi-migrate-legacy to upgrade.' }];
     const { newContent, fixedKeys } = await fixL02('/tmp/fake/sources/x.md', 'sources/x.md', content, findings, []);
     assert.equal(newContent, content, 'created is invalid — date_added must survive for a human to look at');
     assert.deepEqual(fixedKeys, []);
@@ -1264,7 +1264,7 @@ describe('fixL02', () => {
 
   test('legacy "date_added" -> "created": values DISAGREE — never removes "date_added" (real conflict)', async () => {
     const content = `---\nid: x\ntitle: X\ntype: source\ncreated: 2026-01-01\nupdated: 2026-01-01\ndate_added: 2020-05-05\nauthors: []\nyear: 2026\nimportance: 3\nprovenance: replayable\n---\nBody.`;
-    const findings = [{ id: 'L02-frontmatter-types', message: 'Legacy frontmatter field "date_added" was renamed to "created" in v0.1. Run /lumi-migrate-legacy to upgrade.' }];
+    const findings = [{ id: 'L02-frontmatter-types', legacyOldKey: 'date_added', legacyNewKey: 'created', message: 'Legacy frontmatter field "date_added" was renamed to "created" in v0.1. Run /lumi-migrate-legacy to upgrade.' }];
     const { newContent, fixedKeys } = await fixL02('/tmp/fake/sources/x.md', 'sources/x.md', content, findings, []);
     assert.equal(newContent, content, 'created and date_added disagree — kept for manual resolution, not silently resolved either way');
     assert.deepEqual(fixedKeys, []);
@@ -1272,7 +1272,7 @@ describe('fixL02', () => {
 
   test('legacy "date_added" -> "created": equal valid dates — removes "date_added"', async () => {
     const content = `---\nid: x\ntitle: X\ntype: source\ncreated: 2020-05-05\nupdated: 2026-01-01\ndate_added: 2020-05-05\nauthors: []\nyear: 2026\nimportance: 3\nprovenance: replayable\n---\nBody.`;
-    const findings = [{ id: 'L02-frontmatter-types', message: 'Legacy frontmatter field "date_added" was renamed to "created" in v0.1. Run /lumi-migrate-legacy to upgrade.' }];
+    const findings = [{ id: 'L02-frontmatter-types', legacyOldKey: 'date_added', legacyNewKey: 'created', message: 'Legacy frontmatter field "date_added" was renamed to "created" in v0.1. Run /lumi-migrate-legacy to upgrade.' }];
     const { newContent, fixedKeys } = await fixL02('/tmp/fake/sources/x.md', 'sources/x.md', content, findings, []);
     assert.ok(!newContent.includes('date_added:'));
     assert.ok(newContent.includes('created: 2020-05-05'));
@@ -1285,8 +1285,8 @@ describe('fixL02', () => {
     // "TODO") when deciding whether date_added is now redundant.
     const content = `---\nid: x\ntitle: X\ntype: source\ncreated: TODO\nupdated: 2026-01-01\ndate_added: 2019-09-09\nauthors: []\nyear: 2026\nimportance: 3\nprovenance: replayable\n---\nBody.`;
     const findings = [
-      { id: 'L02-frontmatter-types', message: '"created" must be an ISO date (YYYY-MM-DD), got "TODO"' },
-      { id: 'L02-frontmatter-types', message: 'Legacy frontmatter field "date_added" was renamed to "created" in v0.1. Run /lumi-migrate-legacy to upgrade.' },
+      { id: 'L02-frontmatter-types', key: 'created', fieldType: 'iso-date', expected: 'an ISO date (YYYY-MM-DD)', message: '"created" must be an ISO date (YYYY-MM-DD), got "TODO"' },
+      { id: 'L02-frontmatter-types', legacyOldKey: 'date_added', legacyNewKey: 'created', message: 'Legacy frontmatter field "date_added" was renamed to "created" in v0.1. Run /lumi-migrate-legacy to upgrade.' },
     ];
     const { newContent, fixedKeys } = await fixL02('/tmp/fake/sources/x.md', 'sources/x.md', content, findings, []);
     assert.ok(newContent.includes('created: 2019-09-09'), `expected created repaired, got:\n${newContent}`);
@@ -1296,7 +1296,7 @@ describe('fixL02', () => {
 
   test('legacy "url" -> "urls": urls[] already contains the url string — removes "url"', async () => {
     const content = `---\nid: x\ntitle: X\ntype: source\ncreated: 2026-01-01\nupdated: 2026-01-01\nurl: https://arxiv.org/abs/1234\nurls:\n  - https://arxiv.org/abs/1234\nauthors: []\nyear: 2026\nimportance: 3\nprovenance: replayable\n---\nBody.`;
-    const findings = [{ id: 'L02-frontmatter-types', message: 'Legacy frontmatter field "url" was renamed to "urls" in v0.8. Run /lumi-migrate-legacy to upgrade.' }];
+    const findings = [{ id: 'L02-frontmatter-types', legacyOldKey: 'url', legacyNewKey: 'urls', message: 'Legacy frontmatter field "url" was renamed to "urls" in v0.8. Run /lumi-migrate-legacy to upgrade.' }];
     const { newContent, fixedKeys } = await fixL02('/tmp/fake/sources/x.md', 'sources/x.md', content, findings, []);
     assert.ok(!newContent.includes('url:'), `expected "url" removed, got:\n${newContent}`);
     assert.ok(newContent.includes('urls:\n  - https://arxiv.org/abs/1234'), 'urls[] must be untouched');
@@ -1305,7 +1305,7 @@ describe('fixL02', () => {
 
   test('legacy "url" -> "urls": urls[] present but does NOT contain the url string — never removes "url" (real conflict)', async () => {
     const content = `---\nid: x\ntitle: X\ntype: source\ncreated: 2026-01-01\nupdated: 2026-01-01\nurl: https://arxiv.org/abs/1234\nurls:\n  - https://example.com/other\nauthors: []\nyear: 2026\nimportance: 3\nprovenance: replayable\n---\nBody.`;
-    const findings = [{ id: 'L02-frontmatter-types', message: 'Legacy frontmatter field "url" was renamed to "urls" in v0.8. Run /lumi-migrate-legacy to upgrade.' }];
+    const findings = [{ id: 'L02-frontmatter-types', legacyOldKey: 'url', legacyNewKey: 'urls', message: 'Legacy frontmatter field "url" was renamed to "urls" in v0.8. Run /lumi-migrate-legacy to upgrade.' }];
     const { newContent, fixedKeys } = await fixL02('/tmp/fake/sources/x.md', 'sources/x.md', content, findings, []);
     assert.equal(newContent, content, 'urls[] does not carry the legacy value — must not be silently dropped');
     assert.deepEqual(fixedKeys, []);
@@ -1314,8 +1314,8 @@ describe('fixL02', () => {
   test('legacy removal appears alongside an unrelated type-mismatch fix in the same preview/fixedKeys', async () => {
     const content = `---\nid: my-concept\ntitle: My Concept\ntype: concept\ncreated: 2026-01-01\nupdated: 2026-01-01\nkey_sources: []\nrelated_concepts: []\nslug: my-concept\n---\nBody.`;
     const findings = [
-      { id: 'L02-frontmatter-types', message: '"key_sources" must be an array, got string' }, // won't actually apply (already array) — sanity no-op guard
-      { id: 'L02-frontmatter-types', message: 'Legacy frontmatter field "slug" was renamed to "id" in v0.1. Run /lumi-migrate-legacy to upgrade.' },
+      { id: 'L02-frontmatter-types', key: 'key_sources', fieldType: 'array', expected: 'an array', message: '"key_sources" must be an array, got string' }, // won't actually apply (already array) — sanity no-op guard
+      { id: 'L02-frontmatter-types', legacyOldKey: 'slug', legacyNewKey: 'id', message: 'Legacy frontmatter field "slug" was renamed to "id" in v0.1. Run /lumi-migrate-legacy to upgrade.' },
     ];
     const { newContent, fixedKeys } = await fixL02('/tmp/fake/concepts/my-concept.md', 'concepts/my-concept.md', content, findings, []);
     assert.ok(!newContent.includes('slug:'));
@@ -3021,6 +3021,7 @@ describe('--suggest output', () => {
   test('computeSuggestion: L01 unfixable field names the type and says it cannot be inferred', () => {
     const f = {
       id: 'L01-frontmatter-required', fixable: false, fix_applied: false,
+      key: 'year', fieldType: 'number',
       message: 'Missing required frontmatter key: "year" (type: number)',
     };
     const s = computeSuggestion(f);
@@ -3031,6 +3032,7 @@ describe('--suggest output', () => {
   test('computeSuggestion: L02 unfixable field names the expected type', () => {
     const f = {
       id: 'L02-frontmatter-types', fixable: false, fix_applied: false,
+      key: 'importance', fieldType: 'enum', expected: 'one of [1, 2, 3, 4, 5]',
       message: '"importance" must be one of [1, 2, 3, 4, 5], got 99',
     };
     const s = computeSuggestion(f);
@@ -3040,6 +3042,7 @@ describe('--suggest output', () => {
   test('computeSuggestion: unresolved legacy-field conflict names both keys', () => {
     const f = {
       id: 'L02-frontmatter-types', fixable: false, fix_applied: false,
+      legacyOldKey: 'slug', legacyNewKey: 'id',
       message: 'Legacy frontmatter field "slug" was renamed to "id" in v0.1. Run /lumi-migrate-legacy to upgrade.',
     };
     const s = computeSuggestion(f);
@@ -3050,6 +3053,7 @@ describe('--suggest output', () => {
   test('computeSuggestion: a REMOVED legacy field (fixable: true) returns null — --fix already handled it', () => {
     const f = {
       id: 'L02-frontmatter-types', fixable: true, fix_applied: true,
+      legacyOldKey: 'slug', legacyNewKey: 'id',
       message: 'Legacy frontmatter field "slug" was renamed to "id" in v0.1. Run /lumi-migrate-legacy to upgrade.',
     };
     assert.equal(computeSuggestion(f), null);
@@ -3058,12 +3062,14 @@ describe('--suggest output', () => {
   test('computeSuggestion: returns null for a fixable or already-fixed finding', () => {
     const fixableF = {
       id: 'L01-frontmatter-required', fixable: true, fix_applied: false,
+      key: 'authors', fieldType: 'array',
       message: 'Missing required frontmatter key: "authors" (type: array)',
     };
     assert.equal(computeSuggestion(fixableF), null);
 
     const fixedF = {
       id: 'L02-frontmatter-types', fixable: true, fix_applied: true,
+      key: 'key_sources', fieldType: 'array', expected: 'an array',
       message: '"key_sources" must be an array, got string',
     };
     assert.equal(computeSuggestion(fixedF), null);
@@ -3092,6 +3098,7 @@ describe('--suggest output', () => {
     const findings = [{
       id: 'L01-frontmatter-required', severity: 'error', fixable: false,
       file: 'sources/a.md', line: null,
+      key: 'year', fieldType: 'number',
       message: 'Missing required frontmatter key: "year" (type: number)',
       fix_applied: false,
     }];
@@ -3122,6 +3129,7 @@ describe('--suggest output', () => {
     const findings = [{
       id: 'L01-frontmatter-required', severity: 'error', fixable: false,
       file: 'sources/a.md', line: null,
+      key: 'year', fieldType: 'number',
       message: 'Missing required frontmatter key: "year" (type: number)',
       fix_applied: false,
     }];

--- a/src/scripts/reset.mjs
+++ b/src/scripts/reset.mjs
@@ -7,9 +7,10 @@
  * Exit codes: 0 success/dry-run, 2 user error, 3 internal error
  */
 
-import { readdir, rm, stat, writeFile, mkdir } from 'node:fs/promises';
+import { readdir, rm, stat, mkdir } from 'node:fs/promises';
 import { join, resolve, relative, sep, parse as parsePath } from 'node:path';
 import { existsSync } from 'node:fs';
+import { atomicWrite } from './lib/fsx.mjs';
 
 // --- Output helpers ---------------------------------------------------------
 
@@ -198,7 +199,7 @@ async function executeDelete(plan, root) {
 
   for (const r of plan.recreate) {
     await mkdir(resolve(r.path, '..'), { recursive: true });
-    await writeFile(r.path, r.content, 'utf8');
+    await atomicWrite(r.path, r.content);
   }
 
   return count;

--- a/src/scripts/reset.mjs
+++ b/src/scripts/reset.mjs
@@ -13,7 +13,6 @@ import { existsSync } from 'node:fs';
 
 // --- Output helpers ---------------------------------------------------------
 
-const NO_COLOR = process.env.NO_COLOR !== undefined || !process.stdout.isTTY; // eslint-disable-line no-unused-vars
 
 /** @param {string} msg */
 function out(msg) { process.stdout.write(msg + '\n'); }

--- a/src/scripts/reset.mjs
+++ b/src/scripts/reset.mjs
@@ -80,7 +80,7 @@ function safePath(projectRoot, target) {
  * @param {string} dir @param {string} [base]
  * @returns {Promise<{path:string, size:number, isDir:boolean}[]>}
  */
-async function collectEntries(dir, base) {
+async function collectEntries(dir, base, withSizes = true) {
   base = base ?? dir;
   const results = [];
   let entries;
@@ -91,10 +91,14 @@ async function collectEntries(dir, base) {
     const rel  = relative(base, full);
     if (e.isDirectory()) {
       results.push({ path: rel, size: 0, isDir: true });
-      results.push(...await collectEntries(full, base));
+      results.push(...await collectEntries(full, base, withSizes));
     } else {
+      // Only the plan preview reports bytes; the delete path counts files and
+      // discards every size, so it skips a stat() per file.
       let size = 0;
-      try { size = (await stat(full)).size; } catch { /* ignore */ }
+      if (withSizes) {
+        try { size = (await stat(full)).size; } catch { /* ignore */ }
+      }
       results.push({ path: rel, size, isDir: false });
     }
   }
@@ -177,7 +181,7 @@ async function executeDelete(plan, root) {
     safePath(root, target);
 
     if (plan.checkpointsOnly) {
-      const entries = await collectEntries(target).catch(() => []);
+      const entries = await collectEntries(target, undefined, false).catch(() => []);
       for (const e of entries.filter(f => !f.isDir && CHECKPOINT_RE.test(f.path))) {
         const full = join(target, e.path);
         safePath(root, full);
@@ -189,7 +193,7 @@ async function executeDelete(plan, root) {
       for (const e of entries) {
         const full = join(target, e.name);
         safePath(root, full);
-        const pre = await collectEntries(full).catch(() => []);
+        const pre = await collectEntries(full, undefined, false).catch(() => []);
         const fileCount = pre.filter(x => !x.isDir).length || (e.isDirectory() ? 0 : 1);
         await rm(full, { force: false, recursive: true });
         count += fileCount;

--- a/src/scripts/schemas.mjs
+++ b/src/scripts/schemas.mjs
@@ -73,11 +73,29 @@ const LINK_SYNTAX = /** @type {const} */ (['obsidian']);
 /** Supported slug normalisation styles. */
 const SLUG_STYLE = /** @type {const} */ (['kebab-case']);
 
+/**
+ * Valid `confidence` values on a graph EDGE. Distinct from the page-level
+ * `confidence` frontmatter enum below, which also admits 'unverified'.
+ * wiki.mjs validates writes against this; lint.mjs's L08 reports on it.
+ */
+export const EDGE_CONFIDENCE = /** @type {const} */ (['high', 'medium', 'low']);
+
+/**
+ * Safe fallback values for enum fields that have one. wiki.mjs writes them in
+ * `migrate --add-defaults`; lint.mjs's fixL01 writes them for a missing key.
+ * The two used to keep private copies synced by hand.
+ */
+export const LEGACY_ENUM_DEFAULTS = {
+  sources:  { provenance: 'missing', confidence: 'unverified' },
+  concepts: { confidence: 'unverified' },
+};
+
 export const ENUMS = {
   IMPORTANCE,
   BIDI_MODES,
   LINK_SYNTAX,
   SLUG_STYLE,
+  EDGE_CONFIDENCE,
 };
 
 // ---------------------------------------------------------------------------

--- a/src/scripts/wiki.mjs
+++ b/src/scripts/wiki.mjs
@@ -2220,8 +2220,9 @@ async function main(argv) {
           fail('resolve-alias requires <text>', 2);
         }
         const projectRoot = await requireProjectRoot();
-        const allEntities = await listEntities(projectRoot);
-        const foundations = allEntities.filter(e => e.type === 'foundations');
+        // Scoped scan: listEntities walks all 13 entity dirs without a prefix,
+        // and every result but foundations/ was discarded a line later.
+        const foundations = await listEntities(projectRoot, 'foundations');
 
         const needle = text.toLowerCase();
         const matches = [];

--- a/src/scripts/wiki.mjs
+++ b/src/scripts/wiki.mjs
@@ -29,6 +29,8 @@ import {
   ENTITY_DIRS,
   SCHEMA_VERSION,
   REQUIRED_FRONTMATTER,
+  EDGE_CONFIDENCE,
+  LEGACY_ENUM_DEFAULTS,
 } from './schemas.mjs';
 import { sanitizeExternalIdsObject } from './external-ids.mjs';
 import { atomicWrite } from './lib/fsx.mjs';
@@ -46,7 +48,7 @@ import {
 // ---------------------------------------------------------------------------
 
 /** Minimum valid edge confidence values. */
-const CONFIDENCE_VALUES = new Set(['high', 'medium', 'low']);
+const CONFIDENCE_VALUES = new Set(EDGE_CONFIDENCE);
 
 /** Regex for a single frontmatter line: `key: value` */
 const FM_LINE_RE = /^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)/;
@@ -660,10 +662,6 @@ async function setMeta(projectRoot, slug, key, value) {
  * make legacy state explicit so verify/lint can flag what still needs review,
  * rather than silently asserting trust.
  */
-const LEGACY_DEFAULTS = {
-  sources:  { provenance: 'missing', confidence: 'unverified' },
-  concepts: { confidence: 'unverified' },
-};
 
 /**
  * Backfill missing frontmatter fields on legacy entities (sources/concepts).
@@ -680,7 +678,7 @@ async function migrateLegacyDefaults(projectRoot, dryRun) {
   let skipped = 0;
 
   for (const entity of entities) {
-    const defaults = LEGACY_DEFAULTS[entity.type];
+    const defaults = LEGACY_ENUM_DEFAULTS[entity.type];
     if (!defaults) { skipped++; continue; }
 
     const content = await readFile(entity.filePath, 'utf8');

--- a/src/scripts/wiki.mjs
+++ b/src/scripts/wiki.mjs
@@ -1654,6 +1654,44 @@ function emitError(message, code) {
   process.exitCode = code;
 }
 
+/**
+ * Emit the error envelope and exit with that same code. Never returns — the
+ * CLI dispatch paired `emitError(msg, N); process.exit(N);` at every one of
+ * these call sites.
+ * @param {string} message
+ * @param {number} code
+ * @returns {never}
+ */
+function fail(message, code) {
+  emitError(message, code);
+  process.exit(code);
+}
+
+/**
+ * Reject an edge command's endpoint pair: a path-shaped slug must resolve
+ * inside the project, and neither endpoint may contain `..`. Extracted from
+ * three verbatim copies in the dispatch. Never returns on rejection.
+ *
+ * Note the citation and checkpoint subcommands deliberately still carry their
+ * own, narrower checks — they run before requireProjectRoot(), so they have no
+ * projectRoot to validate against, and widening them here would change which
+ * error a user sees outside a project.
+ * @param {string} fromSlug
+ * @param {string} toSlug
+ * @param {string} projectRoot
+ */
+function requireSafeEdgeSlugs(fromSlug, toSlug, projectRoot) {
+  if (fromSlug.includes('/') && !pathSafe(fromSlug, projectRoot)) {
+    fail(`Unsafe from-slug: ${fromSlug}`, 2);
+  }
+  if (toSlug.includes('/') && !pathSafe(toSlug, projectRoot)) {
+    fail(`Unsafe to-slug: ${toSlug}`, 2);
+  }
+  if (fromSlug.includes('..') || toSlug.includes('..')) {
+    fail('Slug may not contain ..', 2);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // 10. CLI dispatch
 // ---------------------------------------------------------------------------
@@ -1695,8 +1733,7 @@ function parseArgs(args) {
 async function requireProjectRoot(startDir) {
   const root = await findProjectRoot(startDir);
   if (!root) {
-    emitError('No Lumina workspace found (wiki/ directory not found in current directory or ancestors). Run `node wiki.mjs init` first.', 2);
-    process.exit(2);
+    fail('No Lumina workspace found (wiki/ directory not found in current directory or ancestors). Run `node wiki.mjs init` first.', 2);
   }
   return root;
 }
@@ -1770,8 +1807,7 @@ async function main(argv) {
         const projectRoot = process.cwd();
         const pack = flags.pack && typeof flags.pack === 'string' ? flags.pack : undefined;
         if (pack && !INSTALLABLE_PACKS.includes(pack)) {
-          emitError(`Invalid --pack value: ${pack}. Must be one of: ${INSTALLABLE_PACKS.join(', ')}.`, 2);
-          process.exit(2);
+          fail(`Invalid --pack value: ${pack}. Must be one of: ${INSTALLABLE_PACKS.join(', ')}.`, 2);
         }
         const result = await initWorkspace(projectRoot, { pack });
         emitJson({ ok: true, created: result.created, skipped: result.skipped });
@@ -1782,8 +1818,7 @@ async function main(argv) {
       case 'slug': {
         const title = positional.join(' ');
         if (!title) {
-          emitError('slug requires a title argument', 2);
-          process.exit(2);
+          fail('slug requires a title argument', 2);
         }
         emitJson({ slug: slugify(title) });
         break;
@@ -1794,12 +1829,10 @@ async function main(argv) {
         const skill = positional[0];
         const details = positional.slice(1).join(' ');
         if (!skill) {
-          emitError('log requires <skill> argument', 2);
-          process.exit(2);
+          fail('log requires <skill> argument', 2);
         }
         if (!details) {
-          emitError('log requires <details> argument', 2);
-          process.exit(2);
+          fail('log requires <details> argument', 2);
         }
         const projectRoot = await requireProjectRoot();
         await appendLog(projectRoot, skill, details);
@@ -1811,13 +1844,11 @@ async function main(argv) {
       case 'read-meta': {
         const slug = positional[0];
         if (!slug) {
-          emitError('read-meta requires <slug> argument', 2);
-          process.exit(2);
+          fail('read-meta requires <slug> argument', 2);
         }
         const projectRoot = await requireProjectRoot();
         if (!pathSafe(slug, projectRoot)) {
-          emitError(`Unsafe slug: ${slug}`, 2);
-          process.exit(2);
+          fail(`Unsafe slug: ${slug}`, 2);
         }
         const { frontmatter, filePath } = await readMeta(projectRoot, slug);
         emitJson({ slug, filePath: relative(projectRoot, filePath), frontmatter });
@@ -1831,14 +1862,12 @@ async function main(argv) {
         const rawValue = positional[2];
 
         if (!slug || !key || rawValue === undefined) {
-          emitError('set-meta requires <slug> <key> <value>', 2);
-          process.exit(2);
+          fail('set-meta requires <slug> <key> <value>', 2);
         }
 
         const projectRoot = await requireProjectRoot();
         if (!pathSafe(slug, projectRoot)) {
-          emitError(`Unsafe slug: ${slug}`, 2);
-          process.exit(2);
+          fail(`Unsafe slug: ${slug}`, 2);
         }
 
         let value;
@@ -1846,8 +1875,7 @@ async function main(argv) {
           try {
             value = JSON.parse(rawValue);
           } catch (err) {
-            emitError(`Invalid JSON value: ${err.message}`, 2);
-            process.exit(2);
+            fail(`Invalid JSON value: ${err.message}`, 2);
           }
         } else {
           // Auto-coerce scalar types (number, boolean) — mirrors YAML parsing behavior.
@@ -1867,25 +1895,13 @@ async function main(argv) {
         const toSlug = positional[2];
 
         if (!fromSlug || !edgeType || !toSlug) {
-          emitError('add-edge requires <from-slug> <edge-type> <to-slug>', 2);
-          process.exit(2);
+          fail('add-edge requires <from-slug> <edge-type> <to-slug>', 2);
         }
 
         const projectRoot = await requireProjectRoot();
 
         // Path safety for slugs (only if they look like paths)
-        if (fromSlug.includes('/') && !pathSafe(fromSlug, projectRoot)) {
-          emitError(`Unsafe from-slug: ${fromSlug}`, 2);
-          process.exit(2);
-        }
-        if (toSlug.includes('/') && !pathSafe(toSlug, projectRoot)) {
-          emitError(`Unsafe to-slug: ${toSlug}`, 2);
-          process.exit(2);
-        }
-        if (fromSlug.includes('..') || toSlug.includes('..')) {
-          emitError('Slug may not contain ..', 2);
-          process.exit(2);
-        }
+        requireSafeEdgeSlugs(fromSlug, toSlug, projectRoot);
 
         const confidence = flags.confidence && typeof flags.confidence === 'string'
           ? flags.confidence
@@ -1902,12 +1918,10 @@ async function main(argv) {
         const toSlug = positional[1];
 
         if (!fromSlug || !toSlug) {
-          emitError('add-citation requires <from-slug> <to-slug>', 2);
-          process.exit(2);
+          fail('add-citation requires <from-slug> <to-slug>', 2);
         }
         if (fromSlug.includes('..') || toSlug.includes('..')) {
-          emitError('Slug may not contain ..', 2);
-          process.exit(2);
+          fail('Slug may not contain ..', 2);
         }
 
         const projectRoot = await requireProjectRoot();
@@ -1922,12 +1936,10 @@ async function main(argv) {
         const toSlug = positional[1];
 
         if (!fromSlug || !toSlug) {
-          emitError('remove-citation requires <from-slug> <to-slug>', 2);
-          process.exit(2);
+          fail('remove-citation requires <from-slug> <to-slug>', 2);
         }
         if (fromSlug.includes('..') || toSlug.includes('..')) {
-          emitError('Slug may not contain ..', 2);
-          process.exit(2);
+          fail('Slug may not contain ..', 2);
         }
 
         const projectRoot = await requireProjectRoot();
@@ -1941,8 +1953,7 @@ async function main(argv) {
       case 'batch-edges': {
         const jsonFile = positional[0];
         if (!jsonFile) {
-          emitError('batch-edges requires <json-file>', 2);
-          process.exit(2);
+          fail('batch-edges requires <json-file>', 2);
         }
         const projectRoot = await requireProjectRoot();
         const resolvedFile = resolve(jsonFile);
@@ -1966,8 +1977,7 @@ async function main(argv) {
         const toSlug = positional[2];
 
         if (!fromSlug || !edgeType || !toSlug) {
-          emitError('remove-edge requires <from-slug> <edge-type> <to-slug>', 2);
-          process.exit(2);
+          fail('remove-edge requires <from-slug> <edge-type> <to-slug>', 2);
         }
 
         if (edgeType === 'cites' || edgeType === 'cited_by') {
@@ -1980,18 +1990,7 @@ async function main(argv) {
 
         const projectRoot = await requireProjectRoot();
 
-        if (fromSlug.includes('/') && !pathSafe(fromSlug, projectRoot)) {
-          emitError(`Unsafe from-slug: ${fromSlug}`, 2);
-          process.exit(2);
-        }
-        if (toSlug.includes('/') && !pathSafe(toSlug, projectRoot)) {
-          emitError(`Unsafe to-slug: ${toSlug}`, 2);
-          process.exit(2);
-        }
-        if (fromSlug.includes('..') || toSlug.includes('..')) {
-          emitError('Slug may not contain ..', 2);
-          process.exit(2);
-        }
+        requireSafeEdgeSlugs(fromSlug, toSlug, projectRoot);
 
         const dryRun = Boolean(flags['dry-run']);
         const result = await removeEdge(projectRoot, fromSlug, edgeType, toSlug, { dryRun });
@@ -2007,8 +2006,7 @@ async function main(argv) {
         const newType = positional[3];
 
         if (!fromSlug || !oldType || !toSlug || !newType) {
-          emitError('replace-edge requires <from-slug> <old-type> <to-slug> <new-type>', 2);
-          process.exit(2);
+          fail('replace-edge requires <from-slug> <old-type> <to-slug> <new-type>', 2);
         }
 
         if ([oldType, newType].includes('cites') || [oldType, newType].includes('cited_by')) {
@@ -2021,18 +2019,7 @@ async function main(argv) {
 
         const projectRoot = await requireProjectRoot();
 
-        if (fromSlug.includes('/') && !pathSafe(fromSlug, projectRoot)) {
-          emitError(`Unsafe from-slug: ${fromSlug}`, 2);
-          process.exit(2);
-        }
-        if (toSlug.includes('/') && !pathSafe(toSlug, projectRoot)) {
-          emitError(`Unsafe to-slug: ${toSlug}`, 2);
-          process.exit(2);
-        }
-        if (fromSlug.includes('..') || toSlug.includes('..')) {
-          emitError('Slug may not contain ..', 2);
-          process.exit(2);
-        }
+        requireSafeEdgeSlugs(fromSlug, toSlug, projectRoot);
 
         const confidence = flags.confidence && typeof flags.confidence === 'string'
           ? flags.confidence
@@ -2049,8 +2036,7 @@ async function main(argv) {
         const skill = positional[0];
         const phase = positional[1];
         if (!skill || !phase) {
-          emitError('checkpoint-read requires <skill> <phase>', 2);
-          process.exit(2);
+          fail('checkpoint-read requires <skill> <phase>', 2);
         }
         const projectRoot = await requireProjectRoot();
         const data = await checkpointRead(projectRoot, skill, phase);
@@ -2065,8 +2051,7 @@ async function main(argv) {
         const source = positional[2]; // json-file path, '-', or undefined (stdin)
 
         if (!skill || !phase) {
-          emitError('checkpoint-write requires <skill> <phase> [<json-file>|-]', 2);
-          process.exit(2);
+          fail('checkpoint-write requires <skill> <phase> [<json-file>|-]', 2);
         }
 
         const projectRoot = await requireProjectRoot();
@@ -2076,8 +2061,7 @@ async function main(argv) {
           try {
             data = await readStdin();
           } catch (err) {
-            emitError(err.message, 2);
-            process.exit(2);
+            fail(err.message, 2);
           }
         } else {
           const absSource = resolve(source);
@@ -2088,8 +2072,7 @@ async function main(argv) {
             const msg = err.code === 'ENOENT'
               ? `File not found: ${source}`
               : `Error reading ${source}: ${err.message}`;
-            emitError(msg, 2);
-            process.exit(2);
+            fail(msg, 2);
           }
         }
 
@@ -2104,12 +2087,10 @@ async function main(argv) {
         const typeFilter = flags.type && typeof flags.type === 'string' ? flags.type : null;
         const prefix = positional[0] || null;
         if (typeFilter && !ENTITY_DIRS[typeFilter]) {
-          emitError(`Unknown entity type: ${typeFilter}. Valid types: ${Object.keys(ENTITY_DIRS).join(', ')}`, 2);
-          process.exit(2);
+          fail(`Unknown entity type: ${typeFilter}. Valid types: ${Object.keys(ENTITY_DIRS).join(', ')}`, 2);
         }
         if (prefix && !pathSafe(prefix, projectRoot)) {
-          emitError(`Unsafe prefix: ${prefix}`, 2);
-          process.exit(2);
+          fail(`Unsafe prefix: ${prefix}`, 2);
         }
         const entities = await listEntities(projectRoot, prefix);
         const filtered = typeFilter ? entities.filter(e => e.type === typeFilter) : entities;
@@ -2130,22 +2111,18 @@ async function main(argv) {
       case 'read-edges': {
         const slug = (flags.from && typeof flags.from === 'string') ? flags.from : positional[0];
         if (!slug) {
-          emitError('read-edges requires <slug> or --from <slug>', 2);
-          process.exit(2);
+          fail('read-edges requires <slug> or --from <slug>', 2);
         }
         if (slug.includes('..')) {
-          emitError('Slug may not contain ..', 2);
-          process.exit(2);
+          fail('Slug may not contain ..', 2);
         }
         const typeFilter = flags.type && typeof flags.type === 'string' ? flags.type : null;
         const direction = flags.direction && typeof flags.direction === 'string' ? flags.direction : 'both';
         if (typeFilter && !edgeTypeByName(typeFilter)) {
-          emitError(`Unknown edge type: ${typeFilter}`, 2);
-          process.exit(2);
+          fail(`Unknown edge type: ${typeFilter}`, 2);
         }
         if (!['outbound', 'inbound', 'both'].includes(direction)) {
-          emitError(`Invalid --direction: ${direction}. Must be outbound, inbound, or both.`, 2);
-          process.exit(2);
+          fail(`Invalid --direction: ${direction}. Must be outbound, inbound, or both.`, 2);
         }
         const projectRoot = await requireProjectRoot();
         const { outbound, inbound } = await readEdgesForSlug(projectRoot, slug, { type: typeFilter, direction });
@@ -2157,12 +2134,10 @@ async function main(argv) {
       case 'read-citations': {
         const slug = positional[0];
         if (!slug) {
-          emitError('read-citations requires <slug>', 2);
-          process.exit(2);
+          fail('read-citations requires <slug>', 2);
         }
         if (slug.includes('..')) {
-          emitError('Slug may not contain ..', 2);
-          process.exit(2);
+          fail('Slug may not contain ..', 2);
         }
         const projectRoot = await requireProjectRoot();
         const { citing, citedBy } = await readCitationsForSlug(projectRoot, slug);
@@ -2174,13 +2149,11 @@ async function main(argv) {
       case 'verify-frontmatter': {
         const slug = positional[0];
         if (!slug) {
-          emitError('verify-frontmatter requires <slug>', 2);
-          process.exit(2);
+          fail('verify-frontmatter requires <slug>', 2);
         }
         const projectRoot = await requireProjectRoot();
         if (!pathSafe(slug, projectRoot)) {
-          emitError(`Unsafe slug: ${slug}`, 2);
-          process.exit(2);
+          fail(`Unsafe slug: ${slug}`, 2);
         }
         const { frontmatter, filePath } = await readMeta(projectRoot, slug);
 
@@ -2231,8 +2204,7 @@ async function main(argv) {
       // -----------------------------------------------------------------------
       case 'migrate': {
         if (!flags['add-defaults']) {
-          emitError('migrate requires --add-defaults (no other migration modes are defined)', 2);
-          process.exit(2);
+          fail('migrate requires --add-defaults (no other migration modes are defined)', 2);
         }
         const projectRoot = await requireProjectRoot();
         const dryRun = Boolean(flags['dry-run']);
@@ -2245,8 +2217,7 @@ async function main(argv) {
       case 'resolve-alias': {
         const text = positional.join(' ').trim();
         if (!text) {
-          emitError('resolve-alias requires <text>', 2);
-          process.exit(2);
+          fail('resolve-alias requires <text>', 2);
         }
         const projectRoot = await requireProjectRoot();
         const allEntities = await listEntities(projectRoot);
@@ -2291,8 +2262,7 @@ async function main(argv) {
         }
 
         if (matches.length === 0) {
-          emitError(`no match for query: ${text}`, 2);
-          process.exit(2);
+          fail(`no match for query: ${text}`, 2);
         }
 
         // Sort ascending by slug for deterministic output
@@ -2308,8 +2278,7 @@ async function main(argv) {
 
       // -----------------------------------------------------------------------
       default: {
-        emitError(`Unknown subcommand: ${subcommand}. Run node wiki.mjs --help for usage.`, 2);
-        process.exit(2);
+        fail(`Unknown subcommand: ${subcommand}. Run node wiki.mjs --help for usage.`, 2);
       }
     }
   } catch (err) {

--- a/src/scripts/wiki.mjs
+++ b/src/scripts/wiki.mjs
@@ -21,18 +21,19 @@
 // ---------------------------------------------------------------------------
 
 import { randomUUID } from 'node:crypto';
-import { open, readFile, rename, unlink, mkdir, access, readdir } from 'node:fs/promises';
+import { readFile, mkdir, access, readdir } from 'node:fs/promises';
 import { constants as fsConstants } from 'node:fs';
 import { dirname, join, resolve, relative, sep } from 'node:path';
 
 import {
   ENTITY_DIRS,
   EDGE_TYPES,
-  EXEMPTION_GLOBS,
   SCHEMA_VERSION,
   REQUIRED_FRONTMATTER,
 } from './schemas.mjs';
 import { sanitizeExternalIdsObject } from './external-ids.mjs';
+import { atomicWrite } from './lib/fsx.mjs';
+import { isExempt } from './lib/globs.mjs';
 
 // ---------------------------------------------------------------------------
 // 2. Constants
@@ -53,32 +54,6 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 // ---------------------------------------------------------------------------
 // 3. Utils
 // ---------------------------------------------------------------------------
-
-/**
- * Write content to path atomically: write to <path>.tmp, fsync fd, rename.
- * @param {string} filePath - Destination path.
- * @param {string} content - String content to write (UTF-8).
- * @returns {Promise<void>}
- */
-async function atomicWrite(filePath, content) {
-  const tmpPath = filePath + '.tmp';
-  let fd;
-  try {
-    fd = await open(tmpPath, 'w');
-    await fd.writeFile(content, 'utf8');
-    await fd.datasync();
-    await fd.close();
-    fd = null;
-    await rename(tmpPath, filePath);
-  } catch (err) {
-    if (fd) {
-      try { await fd.close(); } catch (_) { /* ignore */ }
-    }
-    // Best-effort cleanup of .tmp
-    await unlink(tmpPath).catch(() => {});
-    throw err;
-  }
-}
 
 /**
  * Convert a title string to a kebab-case slug.
@@ -474,46 +449,6 @@ function today() {
   const m = String(d.getMonth() + 1).padStart(2, '0');
   const day = String(d.getDate()).padStart(2, '0');
   return `${y}-${m}-${day}`;
-}
-
-/**
- * Check whether a target slug/path matches any of the exemption globs.
- * Supported glob patterns: `**` anywhere, `*` (single segment).
- * @param {string} target
- * @returns {boolean}
- */
-function isExempt(target) {
-  for (const glob of EXEMPTION_GLOBS) {
-    if (matchGlob(glob, target)) return true;
-  }
-  return false;
-}
-
-/**
- * Simple glob matcher supporting `*` and `**`.
- * @param {string} pattern
- * @param {string} str
- * @returns {boolean}
- */
-function matchGlob(pattern, str) {
-  // Normalize separators
-  const p = pattern.replace(/\\/g, '/');
-  const s = str.replace(/\\/g, '/');
-
-  // Special pattern: *://* matches URLs
-  if (p === '*://*') {
-    return /^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//.test(s);
-  }
-
-  // Convert glob to regex
-  const regexStr = p
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&') // escape regex special chars
-    .replace(/\*\*/g, '{{DOUBLESTAR}}')
-    .replace(/\*/g, '[^/]*')
-    .replace(/{{DOUBLESTAR}}/g, '.*');
-
-  const re = new RegExp(`^${regexStr}$`);
-  return re.test(s);
 }
 
 /**

--- a/src/scripts/wiki.mjs
+++ b/src/scripts/wiki.mjs
@@ -20,12 +20,10 @@
 // 1. Imports + schemas import
 // ---------------------------------------------------------------------------
 
-import { createHash, randomBytes, randomUUID } from 'node:crypto';
-import { open, readFile, writeFile, rename, unlink, mkdir, access, stat, readdir } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { open, readFile, rename, unlink, mkdir, access, readdir } from 'node:fs/promises';
 import { constants as fsConstants } from 'node:fs';
-import { dirname, join, resolve, relative, normalize, sep } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { createReadStream } from 'node:fs';
+import { dirname, join, resolve, relative, sep } from 'node:path';
 
 import {
   ENTITY_DIRS,
@@ -39,9 +37,6 @@ import { sanitizeExternalIdsObject } from './external-ids.mjs';
 // ---------------------------------------------------------------------------
 // 2. Constants
 // ---------------------------------------------------------------------------
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
 
 /** Minimum valid edge confidence values. */
 const CONFIDENCE_VALUES = new Set(['high', 'medium', 'low']);
@@ -221,16 +216,6 @@ function parseFrontmatter(content) {
         currentMapKey = null;
       }
       continue;
-    }
-
-    // Indented list item without matching pattern (fallback)
-    if (line.match(/^\s+-\s/) && currentListKey !== null) {
-      const rawFallback = line.replace(/^\s+-\s+/, '').trim();
-      if (rawFallback.startsWith('{') && rawFallback.endsWith('}')) {
-        frontmatter[currentListKey].push(_parseFlowMapping(rawFallback));
-      } else {
-        frontmatter[currentListKey].push(unquoteValue(rawFallback));
-      }
     }
   }
 
@@ -428,11 +413,9 @@ function quoteIfNeeded(val) {
  * Reassemble a markdown file from parsed frontmatter + body.
  * @param {Record<string,any>} fm
  * @param {string} body
- * @param {boolean} hasFrontmatter
  * @returns {string}
  */
-function assembleMd(fm, body, hasFrontmatter) {
-  if (!hasFrontmatter && Object.keys(fm).length === 0) return body;
+function assembleMd(fm, body) {
   const yamlBlock = stringifyFrontmatter(fm);
   return `---\n${yamlBlock}\n---\n${body}`;
 }
@@ -531,15 +514,6 @@ function matchGlob(pattern, str) {
 
   const re = new RegExp(`^${regexStr}$`);
   return re.test(s);
-}
-
-/**
- * Compute SHA-256 hash of a string.
- * @param {string} content
- * @returns {string} hex digest
- */
-function sha256(content) {
-  return createHash('sha256').update(content, 'utf8').digest('hex');
 }
 
 /**
@@ -677,7 +651,7 @@ async function setMeta(projectRoot, slug, key, value) {
 
   const entityType = _entityTypeForFilePath(projectRoot, filePath);
   if (entityType) {
-    const fields = _getRequiredFrontmatterFields(entityType);
+    const fields = REQUIRED_FRONTMATTER[entityType] ?? null;
     const field = fields ? fields.find((f) => f.key === key) : null;
     // Clearing an OPTIONAL declared field stays allowed. The gate exists to stop
     // wrong-typed values, and `null` on a field the schema marks `required:
@@ -732,7 +706,7 @@ async function setMeta(projectRoot, slug, key, value) {
   } else {
     frontmatter[key] = value;
   }
-  const newContent = assembleMd(frontmatter, body, hasFrontmatter || true);
+  const newContent = assembleMd(frontmatter, body);
   await atomicWrite(filePath, newContent);
   return { filePath };
 }
@@ -782,7 +756,7 @@ async function migrateLegacyDefaults(projectRoot, dryRun) {
     if (Object.keys(added).length === 0) { skipped++; continue; }
 
     if (!dryRun) {
-      const newContent = assembleMd(frontmatter, body, hasFrontmatter || true);
+      const newContent = assembleMd(frontmatter, body);
       await atomicWrite(entity.filePath, newContent);
     }
     updated.push({ slug: entity.slug, type: entity.type, added });
@@ -1731,10 +1705,7 @@ function _checkFieldType(field, val) {
  * @returns {string[]}
  */
 function _validateFrontmatter(frontmatter, entityType) {
-  // Import REQUIRED_FRONTMATTER from the already-imported schemas module.
-  // Because schemas.mjs is pure data, this import is a no-op (already cached).
-  // We use a dynamic import workaround via a re-export alias loaded at startup.
-  const fields = _getRequiredFrontmatterFields(entityType);
+  const fields = REQUIRED_FRONTMATTER[entityType] ?? null;
   if (!fields) return [`Unknown entity type: ${entityType}`];
 
   const errors = [];
@@ -1791,24 +1762,6 @@ function _validateFindingsItems(findings) {
   return errors;
 }
 
-/**
- * Lookup required frontmatter fields for an entity type.
- * Merges _base fields with type-specific fields.
- * @param {string} entityType
- * @returns {import('./schemas.mjs').FrontmatterField[]|null}
- */
-function _getRequiredFrontmatterFields(entityType) {
-  // REQUIRED_FRONTMATTER is imported at module level from schemas.mjs.
-  // We access it through the module-scoped import binding.
-  const typeFields = _REQUIRED_FRONTMATTER[entityType];
-  if (!typeFields) return null;
-  return typeFields;
-}
-
-// Module-level alias to the imported REQUIRED_FRONTMATTER for use by
-// _getRequiredFrontmatterFields without a dynamic import inside the function.
-const _REQUIRED_FRONTMATTER = REQUIRED_FRONTMATTER;
-
 // ---------------------------------------------------------------------------
 // 10. Output helpers
 // ---------------------------------------------------------------------------
@@ -1829,14 +1782,6 @@ function emitJson(data) {
 function emitError(message, code) {
   process.stderr.write(JSON.stringify({ error: message, code }) + '\n');
   process.exitCode = code;
-}
-
-/**
- * Print info/status to stderr (non-JSON, non-blocking).
- * @param {string} message
- */
-function info(message) {
-  process.stderr.write(`[wiki] ${message}\n`);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/scripts/wiki.mjs
+++ b/src/scripts/wiki.mjs
@@ -27,13 +27,19 @@ import { dirname, join, resolve, relative, sep } from 'node:path';
 
 import {
   ENTITY_DIRS,
-  EDGE_TYPES,
   SCHEMA_VERSION,
   REQUIRED_FRONTMATTER,
 } from './schemas.mjs';
 import { sanitizeExternalIdsObject } from './external-ids.mjs';
 import { atomicWrite } from './lib/fsx.mjs';
 import { isExempt } from './lib/globs.mjs';
+import {
+  edgeTypeByName,
+  skipReverseFor,
+  reverseEdgeFor,
+  edgeKey,
+  normalizeEdge,
+} from './lib/edges.mjs';
 
 // ---------------------------------------------------------------------------
 // 2. Constants
@@ -793,36 +799,6 @@ async function writeJsonl(filePath, records) {
 }
 
 /**
- * Create a canonical edge key for deduplication.
- * For symmetric edges: sorted endpoints joined with `|`.
- * For asymmetric edges: `from|type|to`.
- * @param {object} edge
- * @returns {string}
- */
-function edgeKey(edge) {
-  const typeDef = EDGE_TYPES.find(t => t.name === edge.type);
-  if (typeDef && typeDef.symmetric) {
-    const endpoints = [edge.from, edge.to].sort();
-    return `${endpoints[0]}|${edge.type}|${endpoints[1]}`;
-  }
-  return `${edge.from}|${edge.type}|${edge.to}`;
-}
-
-/**
- * Normalize a symmetric edge so endpoints are sorted.
- * @param {object} edge
- * @returns {object}
- */
-function normalizeEdge(edge) {
-  const typeDef = EDGE_TYPES.find(t => t.name === edge.type);
-  if (typeDef && typeDef.symmetric) {
-    const [a, b] = [edge.from, edge.to].sort();
-    return { ...edge, from: a, to: b };
-  }
-  return edge;
-}
-
-/**
  * Add an edge (and its reverse unless target is exempt or edge is terminal).
  * Idempotent: re-running same add-edge produces byte-identical files.
  *
@@ -835,7 +811,7 @@ function normalizeEdge(edge) {
  * @returns {Promise<{added: boolean, reason: string}>}
  */
 async function addEdge(projectRoot, fromSlug, edgeType, toSlug, opts = {}) {
-  const typeDef = EDGE_TYPES.find(t => t.name === edgeType);
+  const typeDef = edgeTypeByName(edgeType);
   if (!typeDef) {
     const err = new Error(`Unknown edge type: ${edgeType}`);
     err.code = 2;
@@ -870,26 +846,9 @@ async function addEdge(projectRoot, fromSlug, edgeType, toSlug, opts = {}) {
 
   const toAdd = [forwardEdge];
 
-  // Add reverse unless:
-  // 1. edge is terminal
-  // 2. target matches EXEMPTION_GLOBS
-  // 3. edge is symmetric (already covered by sorted endpoints)
-  const skipReverse =
-    typeDef.terminal ||
-    isExempt(toSlug) ||
-    typeDef.symmetric;
-
-  if (!skipReverse && typeDef.reverse) {
-    const reverseEdge = {
-      from: toSlug,
-      type: typeDef.reverse,
-      to: fromSlug,
-      ...(opts.confidence ? { confidence: opts.confidence } : {}),
-    };
-    const revKey = edgeKey(reverseEdge);
-    if (!existingKeys.has(revKey)) {
-      toAdd.push(reverseEdge);
-    }
+  const reverseEdge = reverseEdgeFor(typeDef, fromSlug, toSlug, opts.confidence);
+  if (reverseEdge && !existingKeys.has(edgeKey(reverseEdge))) {
+    toAdd.push(reverseEdge);
   }
 
   const newEdges = [...existing, ...toAdd];
@@ -996,7 +955,7 @@ async function batchEdges(projectRoot, jsonFilePath) {
       errors.push(`Record ${i}: missing from, type, or to`);
       continue;
     }
-    const typeDef = EDGE_TYPES.find(t => t.name === rec.type);
+    const typeDef = edgeTypeByName(rec.type);
     if (!typeDef) {
       errors.push(`Record ${i}: unknown edge type '${rec.type}'`);
     }
@@ -1023,7 +982,7 @@ async function batchEdges(projectRoot, jsonFilePath) {
   const toAdd = [];
 
   for (const rec of records) {
-    const typeDef = EDGE_TYPES.find(t => t.name === rec.type);
+    const typeDef = edgeTypeByName(rec.type);
     const forwardEdge = normalizeEdge({
       from: rec.from,
       type: rec.type,
@@ -1041,18 +1000,8 @@ async function batchEdges(projectRoot, jsonFilePath) {
     existingKeys.add(fwdKey);
     added++;
 
-    const skipReverse =
-      typeDef.terminal ||
-      isExempt(rec.to) ||
-      typeDef.symmetric;
-
-    if (!skipReverse && typeDef.reverse) {
-      const reverseEdge = {
-        from: rec.to,
-        type: typeDef.reverse,
-        to: rec.from,
-        ...(rec.confidence ? { confidence: rec.confidence } : {}),
-      };
+    const reverseEdge = reverseEdgeFor(typeDef, rec.from, rec.to, rec.confidence);
+    if (reverseEdge) {
       const revKey = edgeKey(reverseEdge);
       if (!existingKeys.has(revKey)) {
         toAdd.push(reverseEdge);
@@ -1099,18 +1048,6 @@ async function dedupEdges(projectRoot) {
 }
 
 /**
- * Same reverse-skip gate used by addEdge/batchEdges: no reverse edge when the
- * type is terminal, the target is exempt (EXEMPTION_GLOBS), or the type is
- * symmetric (already covered by sorted endpoints).
- * @param {object} typeDef
- * @param {string} toSlug
- * @returns {boolean}
- */
-function skipReverseFor(typeDef, toSlug) {
-  return Boolean(typeDef.terminal || isExempt(toSlug) || typeDef.symmetric);
-}
-
-/**
  * Partition an edge list into the edges matching a from/type/to relationship
  * (forward + its reverse, per the same gate addEdge uses) versus the rest.
  * Confidence is ignored when matching (edgeKey already ignores it).
@@ -1132,7 +1069,7 @@ function partitionEdgesForRemoval(edges, fromSlug, typeDef, toSlug) {
   const fwdKey = edgeKey(normalizeEdge({ from: fromSlug, type: typeDef.name, to: toSlug }));
 
   let revKey = null;
-  if (!skipReverseFor(typeDef, toSlug) && typeDef.reverse) {
+  if (!skipReverseFor(typeDef, toSlug)) {
     revKey = edgeKey(normalizeEdge({ from: toSlug, type: typeDef.reverse, to: fromSlug }));
   }
 
@@ -1213,7 +1150,7 @@ async function collectRemovalAdvisories(projectRoot, fromSlug, toSlug) {
  * @returns {Promise<object>}
  */
 async function removeEdge(projectRoot, fromSlug, edgeType, toSlug, opts = {}) {
-  const typeDef = EDGE_TYPES.find(t => t.name === edgeType);
+  const typeDef = edgeTypeByName(edgeType);
   if (!typeDef) {
     const err = new Error(`Unknown edge type: ${edgeType}`);
     err.code = 2;
@@ -1274,13 +1211,13 @@ async function removeEdge(projectRoot, fromSlug, edgeType, toSlug, opts = {}) {
  * @returns {Promise<object>}
  */
 async function replaceEdge(projectRoot, fromSlug, oldType, toSlug, newType, opts = {}) {
-  const oldTypeDef = EDGE_TYPES.find(t => t.name === oldType);
+  const oldTypeDef = edgeTypeByName(oldType);
   if (!oldTypeDef) {
     const err = new Error(`Unknown edge type: ${oldType}`);
     err.code = 2;
     throw err;
   }
-  const newTypeDef = EDGE_TYPES.find(t => t.name === newType);
+  const newTypeDef = edgeTypeByName(newType);
   if (!newTypeDef) {
     const err = new Error(`Unknown edge type: ${newType}`);
     err.code = 2;
@@ -1324,7 +1261,7 @@ async function replaceEdge(projectRoot, fromSlug, oldType, toSlug, newType, opts
   }
 
   let reverseEdge = null;
-  if (!skipReverseFor(newTypeDef, toSlug) && newTypeDef.reverse) {
+  if (!skipReverseFor(newTypeDef, toSlug)) {
     reverseEdge = { from: toSlug, type: newTypeDef.reverse, to: fromSlug };
     const candidate = { ...reverseEdge, ...(confidence ? { confidence } : {}) };
     const revKey = edgeKey(candidate);
@@ -2204,7 +2141,7 @@ async function main(argv) {
         }
         const typeFilter = flags.type && typeof flags.type === 'string' ? flags.type : null;
         const direction = flags.direction && typeof flags.direction === 'string' ? flags.direction : 'both';
-        if (typeFilter && !EDGE_TYPES.some(t => t.name === typeFilter)) {
+        if (typeFilter && !edgeTypeByName(typeFilter)) {
           emitError(`Unknown edge type: ${typeFilter}`, 2);
           process.exit(2);
         }


### PR DESCRIPTION
Quality-only pass over `src/scripts/` (`/simplify`). No user-visible behaviour change: `--json` output and post-`--fix` trees are byte-identical to `main`, verified on a generated 1200-page wiki and a purpose-built fixture.

## Why

Several rules were spelled out in more than one place, and the copies had already drifted apart. Each was collapsed to a single definition, taking the strictest behaviour where they disagreed.

- **`atomicWrite` x4 + one bare `writeFile`.** The copy in `lint.mjs` was missing `fd.datasync()` despite a docstring claiming "fsync via close" — so `lint --fix`, the write path with the widest blast radius, ran without the durability guarantee CLAUDE.md mandates. Now `lib/fsx.mjs`.
- **`isExempt` x2**, two different readings of the same `EXEMPTION_GLOBS`; they disagreed on a bare `foundations` target. Now `lib/globs.mjs`, keeping the *writer's* semantics — if the linter demanded a reverse edge the writer refuses to create, `--fix` would loop forever.
- **The reverse-edge gate, written out in 6 places**, and the `skipReverseFor` helper was the copy *missing* `!typeDef.reverse` — every call site re-added it by hand, so anyone trusting the helper would write an `appears_in` edge with `type: null`. Now `lib/edges.mjs`, checked against the old inline expression across all 42 edge types.
- **9 sites regex-parsed English message strings** to recover a finding's field key/type. Rewording a message silently broke the corresponding fixer. Findings now carry structured fields.
- `fail()` replaces 45 `emitError` + `process.exit` pairs; `requireSafeEdgeSlugs()` replaces 3 verbatim blocks; `splitRawFrontmatter` was a verbatim copy of `parseFrontmatter`'s head and is folded back in; `LEGACY_ENUM_DEFAULTS` / `EDGE_CONFIDENCE` / `VALID_SCHEDULES` move to their source of truth; 13 `EDGE_TYPES.find()` scans become a Map; the parallel `scriptByName`/`argsByName` tables become one `FETCHERS` row per provider.
- `copyScripts()` derives the `lib/` file list from the package instead of hardcoding it — `lib/` is now load-bearing for `wiki.mjs` and `lint.mjs`, and the surrounding `catch (_) {}` would have hidden a forgotten file until a user ran a skill.

## Performance

`lint` on 1200 pages: **0.30s -> 0.06s (~5x)**, output byte-identical.

- `buildBasenameIndex` rebuilt the whole Map once per scanned file (O(N^2)) — memoized.
- Each file was read three times — one snapshot with a pool of 32.
- The wikilink regex was reallocated per line — hoisted (line-wise scanning kept deliberately, since `[^\]|]+` matches newlines).
- `reset` dropped a per-file `stat` used only for counting; `resolve-alias` no longer scans 13 directories to read one.

## Fixed along the way

- `--suggest` no longer truncates enum lists (`expected one of [high,` -> the full list).
- `fetchSource('rss')` errors instead of calling `spawnSync(undefined)`.

## Verification

875 tests pass (installer 377, scripts 468, e2e 19, catalog 11). `ci:package`, `ci:idempotency` (all 5 profiles), `ci:agent-isolation` green; cold-start 249ms against a 350ms budget.

Beyond the suite: `--json` and the post-`--fix` file tree are byte-identical on fixtures covering `---id: x`, absent frontmatter and an unclosed block; a 22-case CLI error battery produces identical stderr envelopes and exit codes; and a fresh sandbox install passes an end-to-end smoke run (init, add-edge, set-meta, lint --fix, lint --json, reset --dry-run) leaving no temp files.

## Not included

Correctness bugs found while reviewing were deliberately left out of a quality-only pass and are being fixed separately — most urgently `lint --fix` destroying a valid page when two files normalize to the same kebab slug (`rename()` overwrites silently), and the same fixer crashing with ENOENT on the second of two L03 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)