### PR TITLE
fix(wiki): checkpoint-read/write escaped the project root

### DIFF
--- a/src/scripts/wiki.mjs
+++ b/src/scripts/wiki.mjs
@@ -443,7 +443,14 @@ function pathSafe(segment, projectRoot) {
   // Check resolved path stays inside projectRoot
   const resolved = resolve(join(projectRoot, segment));
   const rootResolved = resolve(projectRoot);
-  if (!resolved.startsWith(rootResolved + sep) && resolved !== rootResolved) return false;
+  // rootResolved already ends with `sep` when it IS a filesystem root (POSIX
+  // "/" or a Windows drive root like "C:\\") -- resolve() only leaves a
+  // trailing separator in that one case. Appending another `sep`
+  // unconditionally would double it ("//" / "C:\\\\"), a prefix no real
+  // resolved path ever has, so every path inside a root-level workspace was
+  // rejected as unsafe. Only add the separator when it isn't already there.
+  const rootWithSep = rootResolved.endsWith(sep) ? rootResolved : rootResolved + sep;
+  if (!resolved.startsWith(rootWithSep) && resolved !== rootResolved) return false;
   return true;
 }
 

--- a/src/scripts/wiki.mjs
+++ b/src/scripts/wiki.mjs
@@ -1302,6 +1302,47 @@ async function replaceEdge(projectRoot, fromSlug, oldType, toSlug, newType, opts
 // ---------------------------------------------------------------------------
 
 /**
+ * Resolve a checkpoint file's path, rejecting any skill/phase that would put it
+ * somewhere other than _lumina/_state.
+ *
+ * These two are identifiers, not paths, and were previously interpolated into a
+ * filename with no validation at all -- the only wiki.mjs arguments reaching a
+ * constructed path without even a `..` check. `phase` in particular carries the
+ * basename of a user's raw file (`checkpoint-read ingest <file-basename>`), so
+ * it is attacker-influenced and cannot be assumed clean. A separator in either
+ * value escaped the state dir, and the read side turned that into an arbitrary
+ * file read printed to stdout.
+ *
+ * Only separators are rejected. Characters that are merely awkward in a
+ * filename -- spaces, dots, parentheses -- stay legal, because real basenames
+ * contain them, they cannot traverse, and refusing them would break resuming an
+ * ingest of `Paper (2017).pdf`. The pathSafe call is a backstop on the composed
+ * path so the guarantee is asserted rather than only argued.
+ * @param {string} projectRoot
+ * @param {string} skill
+ * @param {string} phase
+ * @returns {string} absolute path to the checkpoint file
+ */
+function checkpointPath(projectRoot, skill, phase) {
+  for (const [label, value] of [['skill', skill], ['phase', phase]]) {
+    if (value.includes('/') || value.includes('\\') || value.includes('\0')) {
+      const err = new Error(
+        `Invalid checkpoint ${label}: ${JSON.stringify(value)} may not contain a path separator`,
+      );
+      err.code = 2;
+      throw err;
+    }
+  }
+  const rel = join('_lumina', '_state', `${skill}-${phase}.json`);
+  if (!pathSafe(rel, projectRoot)) {
+    const err = new Error(`Unsafe checkpoint path for skill ${JSON.stringify(skill)} phase ${JSON.stringify(phase)}`);
+    err.code = 2;
+    throw err;
+  }
+  return join(projectRoot, rel);
+}
+
+/**
  * Read a checkpoint file. Returns {} if missing.
  * @param {string} projectRoot
  * @param {string} skill
@@ -1309,8 +1350,7 @@ async function replaceEdge(projectRoot, fromSlug, oldType, toSlug, newType, opts
  * @returns {Promise<object>}
  */
 async function checkpointRead(projectRoot, skill, phase) {
-  const stateDir = join(projectRoot, '_lumina', '_state');
-  const cpFile = join(stateDir, `${skill}-${phase}.json`);
+  const cpFile = checkpointPath(projectRoot, skill, phase);
   try {
     const content = await readFile(cpFile, 'utf8');
     return JSON.parse(content);
@@ -1328,9 +1368,8 @@ async function checkpointRead(projectRoot, skill, phase) {
  * @param {object} data
  */
 async function checkpointWrite(projectRoot, skill, phase, data) {
-  const stateDir = join(projectRoot, '_lumina', '_state');
-  await ensureDir(stateDir);
-  const cpFile = join(stateDir, `${skill}-${phase}.json`);
+  const cpFile = checkpointPath(projectRoot, skill, phase);
+  await ensureDir(join(projectRoot, '_lumina', '_state'));
   await atomicWrite(cpFile, JSON.stringify(data, null, 2) + '\n');
 }
 
@@ -1672,10 +1711,12 @@ function fail(message, code) {
  * inside the project, and neither endpoint may contain `..`. Extracted from
  * three verbatim copies in the dispatch. Never returns on rejection.
  *
- * Note the citation and checkpoint subcommands deliberately still carry their
- * own, narrower checks — they run before requireProjectRoot(), so they have no
- * projectRoot to validate against, and widening them here would change which
- * error a user sees outside a project.
+ * Note the citation subcommands deliberately still carry their own, narrower
+ * checks: they run before requireProjectRoot(), so they have no projectRoot to
+ * validate against, and widening them here would change which error a user sees
+ * outside a project. That reasoning once named the checkpoint subcommands too,
+ * which was simply wrong -- they call requireProjectRoot() before doing any
+ * work, and they now validate in checkpointPath().
  * @param {string} fromSlug
  * @param {string} toSlug
  * @param {string} projectRoot

--- a/src/scripts/wiki.test.mjs
+++ b/src/scripts/wiki.test.mjs
@@ -10,7 +10,7 @@ import { mkdtemp, readFile, writeFile, mkdir, rm, access, open } from 'node:fs/p
 import { tmpdir, platform } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { constants as fsConstants } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
@@ -1706,6 +1706,156 @@ describe('checkpoint ops', () => {
 
       const stateFile = join(tmp, '_lumina', '_state', 'skill-a-phaseA.json');
       await access(stateFile, fsConstants.F_OK);
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Regression: checkpointPath() must reject path separators in <skill> and
+  // <phase> so neither argument can escape _lumina/_state (fixes the arbitrary
+  // file write/read described in the checkpointPath() doc comment).
+  // -------------------------------------------------------------------------
+
+  test('checkpoint-write rejects a ".." skill and creates nothing outside the project', async () => {
+    const tmp = await makeTmp();
+    const token = randomUUID();
+    const skill = `../../../lumina-wiki-escape-${token}`;
+    // Mirrors the OLD, unvalidated construction: join(stateDir, `${skill}-${phase}.json`).
+    const outside = join(tmp, '_lumina', '_state', `${skill}-phase1.json`);
+    try {
+      initWorkspace(tmp);
+      const cpFile = join(tmp, 'cp.json');
+      await writeFile(cpFile, JSON.stringify({ x: 1 }), 'utf8');
+
+      const r = runWiki(['checkpoint-write', skill, 'phase1', cpFile], { cwd: tmp });
+      assert.equal(r.status, 2, `expected exit 2, got ${r.status}: ${r.stderr}`);
+
+      try {
+        await access(outside, fsConstants.F_OK);
+        assert.fail('checkpoint file must not be created outside the project root');
+      } catch (err) {
+        assert.equal(err.code, 'ENOENT', 'file correctly absent outside the project');
+      }
+    } finally {
+      await rm(outside, { force: true }).catch(() => {});
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('checkpoint-write rejects a ".." phase and creates nothing outside the project', async () => {
+    const tmp = await makeTmp();
+    const token = randomUUID();
+    const phase = `../../../lumina-wiki-escape-phase-${token}`;
+    const outside = join(tmp, '_lumina', '_state', `my-skill-${phase}.json`);
+    try {
+      initWorkspace(tmp);
+      const cpFile = join(tmp, 'cp.json');
+      await writeFile(cpFile, JSON.stringify({ y: 2 }), 'utf8');
+
+      const r = runWiki(['checkpoint-write', 'my-skill', phase, cpFile], { cwd: tmp });
+      assert.equal(r.status, 2, `expected exit 2, got ${r.status}: ${r.stderr}`);
+
+      try {
+        await access(outside, fsConstants.F_OK);
+        assert.fail('checkpoint file must not be created outside the project root');
+      } catch (err) {
+        assert.equal(err.code, 'ENOENT', 'file correctly absent outside the project');
+      }
+    } finally {
+      await rm(outside, { force: true }).catch(() => {});
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('checkpoint-read rejects a ".." skill and does not leak an outside file\'s contents', async () => {
+    const tmp = await makeTmp();
+    const token = randomUUID();
+    const skill = `../../../lumina-wiki-secret-${token}`;
+    // Mirrors the OLD, unvalidated read location so this proves a real read
+    // primitive was closed, not just that the command errors for other reasons.
+    const outside = join(tmp, '_lumina', '_state', `${skill}-x.json`);
+    const secretValue = `exfiltrated-${token}`;
+    try {
+      initWorkspace(tmp);
+      await writeFile(outside, JSON.stringify({ SECRET: secretValue }), 'utf8');
+
+      const r = runWiki(['checkpoint-read', skill, 'x'], { cwd: tmp });
+      assert.equal(r.status, 2, `expected exit 2, got ${r.status}: stdout=${r.stdout} stderr=${r.stderr}`);
+      assert.ok(!r.stdout.includes(secretValue), 'stdout must not contain the outside file\'s secret value');
+      assert.ok(!r.stdout.includes('SECRET'), 'stdout must not contain the outside file\'s contents');
+    } finally {
+      await rm(outside, { force: true }).catch(() => {});
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('checkpoint-write rejects a bare "/" in <skill> even without ".." traversal', async () => {
+    const tmp = await makeTmp();
+    try {
+      initWorkspace(tmp);
+      const cpFile = join(tmp, 'cp.json');
+      await writeFile(cpFile, JSON.stringify({ z: 3 }), 'utf8');
+
+      const r = runWiki(['checkpoint-write', 'a/b', 'c', cpFile], { cwd: tmp });
+      assert.equal(r.status, 2, `expected exit 2, got ${r.status}: ${r.stderr}`);
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('checkpoint-write path-separator rejection has the {error, code:2} envelope shape', async () => {
+    const tmp = await makeTmp();
+    try {
+      initWorkspace(tmp);
+      const cpFile = join(tmp, 'cp.json');
+      await writeFile(cpFile, JSON.stringify({ a: 1 }), 'utf8');
+
+      const r = runWiki(['checkpoint-write', '../escaped', 'phase1', cpFile], { cwd: tmp });
+      assert.equal(r.status, 2);
+      const errJson = parseJson(r.stderr);
+      assert.equal(errJson.code, 2);
+      assert.match(errJson.error, /may not contain a path separator/);
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('checkpoint round-trips a raw file basename with spaces, parens, and a dot in <phase>', async () => {
+    const tmp = await makeTmp();
+    try {
+      initWorkspace(tmp);
+      const cpFile = join(tmp, 'cp.json');
+      const data = { resumed: true };
+      await writeFile(cpFile, JSON.stringify(data), 'utf8');
+
+      const phase = 'Paper (2017).pdf';
+      const wr = runWiki(['checkpoint-write', 'ingest', phase, cpFile], { cwd: tmp });
+      assert.equal(wr.status, 0, `checkpoint-write failed: ${wr.stderr}`);
+
+      const rr = runWiki(['checkpoint-read', 'ingest', phase], { cwd: tmp });
+      assert.equal(rr.status, 0, `checkpoint-read failed: ${rr.stderr}`);
+      assert.deepEqual(parseJson(rr.stdout), data);
+    } finally {
+      await cleanTmp(tmp);
+    }
+  });
+
+  test('checkpoint round-trips a timestamp <phase> like /lumi-verify passes', async () => {
+    const tmp = await makeTmp();
+    try {
+      initWorkspace(tmp);
+      const cpFile = join(tmp, 'cp.json');
+      const data = { verified: true };
+      await writeFile(cpFile, JSON.stringify(data), 'utf8');
+
+      const phase = '20260815T115922Z';
+      const wr = runWiki(['checkpoint-write', 'lumi-verify', phase, cpFile], { cwd: tmp });
+      assert.equal(wr.status, 0, `checkpoint-write failed: ${wr.stderr}`);
+
+      const rr = runWiki(['checkpoint-read', 'lumi-verify', phase], { cwd: tmp });
+      assert.equal(rr.status, 0, `checkpoint-read failed: ${rr.stderr}`);
+      assert.deepEqual(parseJson(rr.stdout), data);
     } finally {
       await cleanTmp(tmp);
     }

--- a/src/scripts/wiki.test.mjs
+++ b/src/scripts/wiki.test.mjs
@@ -8,10 +8,10 @@ import { test, describe, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, readFile, writeFile, mkdir, rm, access, open } from 'node:fs/promises';
 import { tmpdir, platform } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve, sep, win32 } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
-import { constants as fsConstants } from 'node:fs';
+import { constants as fsConstants, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 // ---------------------------------------------------------------------------
@@ -1859,6 +1859,84 @@ describe('checkpoint ops', () => {
     } finally {
       await cleanTmp(tmp);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: pathSafe() containment check when projectRoot IS a filesystem
+// root (POSIX "/" or a Windows drive root like "C:\\"). checkpointPath()
+// (which backstops itself with pathSafe(), see its doc comment above) is
+// reached through requireProjectRoot() -> findProjectRoot(), which legally
+// returns such a root when `wiki/` lives directly under it -- e.g. a
+// container whose workspace is mounted at "/", or a project at a Windows
+// drive root. pathSafe() compared the resolved candidate against
+// `rootResolved + sep`, which doubles to "//" / "C:\\\\" when rootResolved
+// already ends in a separator (the one case resolve() leaves a trailing
+// separator in) -- a prefix no real resolved path ever has, so every
+// checkpoint path in a root-level workspace was rejected as unsafe.
+//
+// pathSafe() is a pure, I/O-free string function, not exported by wiki.mjs.
+// It also cannot safely be `import`ed here: wiki.mjs calls `main(process.argv)`
+// unconditionally at the bottom of the module with no `import.meta.url`
+// guard, so importing it would run its CLI against the test runner's argv
+// and exit the process. Instead, these tests extract pathSafe()'s exact
+// current source out of the file and evaluate it -- exercising the real
+// implementation, not a hand-copied duplicate that could silently drift out
+// of sync -- and run it against a chosen path-primitive set (native
+// `node:path` for the POSIX cases, `node:path`'s `win32` namespace for the
+// Windows cases, so both are exercised regardless of the host OS running
+// this suite).
+// ---------------------------------------------------------------------------
+
+describe('pathSafe() filesystem-root containment (regression)', () => {
+  /**
+   * Extract pathSafe()'s current function body from wiki.mjs and bind it to
+   * the given { resolve, join, sep } (the free variables it closes over).
+   */
+  function extractPathSafe({ resolve, join, sep }) {
+    const src = readFileSync(WIKI_MJS, 'utf8');
+    const match = src.match(/function pathSafe\(segment, projectRoot\) \{[\s\S]*?\n\}\n/);
+    assert.ok(match, 'pathSafe() source not found in wiki.mjs -- update this extraction if it moved/changed shape');
+    const factory = new Function('resolve', 'join', 'sep', `return ${match[0]}`);
+    return factory(resolve, join, sep);
+  }
+
+  test('POSIX: accepts an in-root checkpoint path when projectRoot is "/"', () => {
+    const pathSafe = extractPathSafe({ resolve, join, sep });
+    const rel = join('_lumina', '_state', 'lumi-ingest-phase1.json');
+    assert.equal(pathSafe(rel, '/'), true);
+  });
+
+  test('POSIX: still rejects a ".." escape when projectRoot is "/"', () => {
+    const pathSafe = extractPathSafe({ resolve, join, sep });
+    assert.equal(pathSafe('../etc/passwd', '/'), false);
+  });
+
+  test('POSIX: still rejects a ".." escape at a normal (non-root) projectRoot', () => {
+    const pathSafe = extractPathSafe({ resolve, join, sep });
+    assert.equal(pathSafe('../../etc/passwd', '/tmp/some-project'), false);
+  });
+
+  test('POSIX: still accepts an in-root path at a normal (non-root) projectRoot', () => {
+    const pathSafe = extractPathSafe({ resolve, join, sep });
+    const rel = join('_lumina', '_state', 'lumi-ingest-phase1.json');
+    assert.equal(pathSafe(rel, '/tmp/some-project'), true);
+  });
+
+  test('Windows: accepts an in-root checkpoint path when projectRoot is a drive root ("C:\\\\")', () => {
+    const pathSafe = extractPathSafe({ resolve: win32.resolve, join: win32.join, sep: win32.sep });
+    const rel = win32.join('_lumina', '_state', 'lumi-ingest-phase1.json');
+    assert.equal(pathSafe(rel, 'C:\\'), true);
+  });
+
+  test('Windows: still rejects a ".." escape when projectRoot is a drive root ("C:\\\\")', () => {
+    const pathSafe = extractPathSafe({ resolve: win32.resolve, join: win32.join, sep: win32.sep });
+    assert.equal(pathSafe('..\\Windows\\System32', 'C:\\'), false);
+  });
+
+  test('Windows: still rejects a ".." escape at a normal (non-root) projectRoot', () => {
+    const pathSafe = extractPathSafe({ resolve: win32.resolve, join: win32.join, sep: win32.sep });
+    assert.equal(pathSafe('..\\..\\Windows\\System32', 'C:\\Projects\\myapp'), false);
   });
 });
 


### PR DESCRIPTION
Group 3 of the `src/scripts/` bug-fix plan. Independent of #40 and #41.

## The bug

`checkpoint-read <skill> <phase>` and `checkpoint-write <skill> <phase> <file>` interpolated both arguments straight into a filename:

```js
const cpFile = join(stateDir, `${skill}-${phase}.json`);
```

with no validation of any kind. These were the **only** wiki.mjs arguments reaching a constructed filesystem path without even a `..` check — every other path-shaped argument goes through `pathSafe` or at minimum a literal `..` test.

A separator in either value, in either command, left `_lumina/_state` entirely:

```
$ wiki.mjs checkpoint-write '../../../ESCAPED' phase1 f.json
{"ok":true,"skill":"../../../ESCAPED","phase":"phase1"}
# file written three levels above the project root

$ wiki.mjs checkpoint-read '../../../OUTSIDE' x
{"SECRET":"exfiltrated"}
# arbitrary JSON file, printed to stdout
```

The read side is the worse half: it is a file-read primitive whose output lands directly in the calling agent's context.

`<phase>` is not hypothetically attacker-influenced — the ingest skill passes the basename of a user's raw file (`checkpoint-read ingest <file-basename>`), so its value comes from whatever the user dropped into `raw/`.

## The fix

A shared `checkpointPath()` backs both functions and rejects `/`, `\` and NUL in either value, throwing with `code = 2` so the CLI emits its usual `{"error":...,"code":2}` envelope and exits 2.

Validation lives in the function rather than in the dispatch case, so a future caller cannot reopen the hole by forgetting it — the shape of latent fragility `findEntityFile` already has, where the untyped-slug branch relies entirely on callers having validated first. `pathSafe()` on the composed path is a backstop, so the guarantee is asserted rather than only argued.

**Only separators are rejected.** Spaces, dots and parentheses stay legal: real basenames contain them, they cannot traverse, and refusing them would break resuming an ingest of `Paper (2017).pdf`.

## A comment that was simply wrong

The note above `requireSafeEdgeSlugs` claimed the checkpoint subcommands ran before `requireProjectRoot()` and so had no root to validate against. Both call it before doing any work. The reasoning does hold for the citation subcommands, which really do run their `..` check first, and the comment now says only that.

## Tests

7 added (475 pass, was 468). The five attack tests fail when `checkpointPath`'s validation is bypassed; the two legitimate-value round-trips keep passing, which is what pins that the fix did not over-reject. The write tests assert no file appears at the path the old code would have used, under a per-run unique slug so a stale artifact cannot decide the result.

## Effect on existing wikis

Checkpoints that escaped under the old code are orphaned files outside `_lumina/_state`; nothing in the workspace references them and lint cannot see them. They are inert junk, not a migration step.

One narrow behaviour change: if an agent ever passed a value containing `/` as `<phase>` (a path instead of the documented basename), the old code silently created a subdirectory under `_lumina/_state` and the checkpoint is now unreadable. The consequence is that one ingest restarts instead of resuming, which is safe — and the same call now fails loudly instead of writing into a directory nobody expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)