### PR TITLE
fix(lint): L03 rename overwrote pages, aborted the run, and mangled non-ASCII names

### DIFF
--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -292,7 +292,7 @@ Lint enforces:
 
 ### `src/scripts/lint.mjs`
 
-`node lint.mjs [path] [--fix] [--dry-run] [--suggest] [--json]`. `ALL_CHECK_IDS` in `src/scripts/lint.mjs` runs L01-L14 + L16-L17 (15 checks total; L15 is intentionally unassigned — reserved slot for a future collision check, deferred as premature for typical wiki size):
+`node lint.mjs [path] [--fix] [--dry-run] [--suggest] [--json]`. `ALL_CHECK_IDS` in `src/scripts/lint.mjs` runs L01-L14 + L16-L18 (L15 is intentionally unassigned — reserved slot for a future collision check, deferred as premature for typical wiki size):
 
 | Check | Description | Fixable |
 |---|---|---|
@@ -312,6 +312,7 @@ Lint enforces:
 | L14 | `external_ids` value fails `normalizeExternalId` (error) | no |
 | L16 | `external_ids[ns]` disagrees with `urls[]`-derived value (warning) | no |
 | L17 | Dangling edge — an edge's `from`/`to` internal slug does not resolve to any wiki file (error) | no |
+| L18 | Frontmatter `id` no longer names the file it lives in, per `deriveIdFromPath` (warning) | no |
 
 Exit codes: `0` clean, `1` unresolved violations, `2` user error, `3` internal. `--dry-run` implies fix intent but zero writes; sets `proposed_fix` instead of `fix_applied`.
 

--- a/src/scripts/lib/slug.mjs
+++ b/src/scripts/lib/slug.mjs
@@ -1,0 +1,45 @@
+/**
+ * ─────────────────────────────────────────────────────────────────────────────
+ * slug.mjs — title/basename to kebab-case slug
+ *
+ * One definition, shared. `wiki.mjs slug` names new pages with it and
+ * `lint.mjs` renames existing ones to it (L03), so the two must agree: a
+ * second, hand-written kebab transform in the fixer meant `lint --fix` could
+ * rename a page to something `wiki.mjs slug` would never have produced for the
+ * same title. Pure function, no I/O — importable from either side.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+// U+0300..U+036F — the Combining Diacritical Marks block, i.e. exactly what
+// NFD scatters a decomposable accented letter into. Written as escapes: the
+// literal characters are invisible in an editor and do not survive a careless
+// copy between files.
+const COMBINING_MARKS = /[̀-ͯ]/g;
+
+/**
+ * Convert a title string to a kebab-case slug.
+ * Lowercase, hyphenate, strip punctuation, collapse whitespace.
+ *
+ * Letters with no canonical decomposition (`đ`, `ø`, `æ`, `ß`, `ł`, `þ`)
+ * survive NFD intact and are then dropped as punctuation rather than
+ * transliterated — `Đổi Mới` slugs to `oi-moi`. That is a known wart, left
+ * alone deliberately: changing it changes the slug for a title a wiki may
+ * already have a page under, so it needs a migration path, not a patch.
+ *
+ * @param {string} title
+ * @returns {string}
+ */
+export function slugify(title) {
+  return title
+    .toLowerCase()
+    // Replace accented chars with ascii equivalents where possible
+    .normalize('NFD')
+    .replace(COMBINING_MARKS, '')
+    // Replace non-alphanumeric (except spaces and hyphens) with space
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    // Collapse any whitespace and hyphens to a single hyphen
+    .trim()
+    .replace(/[\s-]+/g, '-')
+    // Remove leading/trailing hyphens
+    .replace(/^-+|-+$/g, '');
+}

--- a/src/scripts/lint.mjs
+++ b/src/scripts/lint.mjs
@@ -1,6 +1,6 @@
 /**
  * @module lint
- * @description LuminaWiki v0.1 wiki linter — 11 schema checks, optional --fix.
+ * @description LuminaWiki v0.1 wiki linter — schema checks, optional --fix.
  *
  * CLI usage:
  *   node lint.mjs [path] [--fix] [--dry-run] [--suggest] [--json] [--summary]
@@ -62,6 +62,7 @@ import {
 } from './external-ids.mjs';
 import { atomicWrite } from './lib/fsx.mjs';
 import { isExempt } from './lib/globs.mjs';
+import { slugify } from './lib/slug.mjs';
 import {
   edgeTypeByName,
   skipReverseFor,
@@ -85,7 +86,7 @@ const isIndexExempt = (f) => INDEX_EXEMPT_PREFIXES.some(p => f.startsWith(p));
 /** All check IDs in run order.
  *  L15 is intentionally absent — collision check was deferred as premature
  *  for typical wiki size. Adding L15 later is the natural next slot. */
-const ALL_CHECK_IDS = ['L01', 'L02', 'L03', 'L04', 'L05', 'L06', 'L07', 'L08', 'L09', 'L10', 'L11', 'L12', 'L13', 'L14', 'L16', 'L17'];
+const ALL_CHECK_IDS = ['L01', 'L02', 'L03', 'L04', 'L05', 'L06', 'L07', 'L08', 'L09', 'L10', 'L11', 'L12', 'L13', 'L14', 'L16', 'L17', 'L18'];
 
 /**
  * Legacy frontmatter fields that have been renamed across versions.
@@ -1742,6 +1743,55 @@ function checkL17(edges, knownSlugs) {
   return findings;
 }
 
+/**
+ * L18: the frontmatter `id` still names the file it lives in.
+ *
+ * Nothing resolves a page by its `id` — every lookup goes through the filename
+ * — so a stale one is inert, silent, and permanent. It is also the fingerprint
+ * of a page an older `lint --fix` renamed without updating: L03 stops firing
+ * the moment the basename is kebab-case, and no other check ever compared the
+ * two. Reported, never repaired: an author who chose a different `id` on
+ * purpose would lose it, and the correct value is not always guessable.
+ *
+ * `deriveIdFromPath` supplies the expected shape, which is not one rule but
+ * three — bare basename on flat dirs, full wiki-relative path on nested ones,
+ * `reflection-` prefix under reflections/.
+ * @param {string} wikiRelPath
+ * @param {object} fm  Parsed frontmatter.
+ * @returns {Finding[]}
+ */
+function checkL18(wikiRelPath, fm) {
+  // Same gate L01/L02 use: a dir with no field spec (`graph/`, `outputs/`) has
+  // no `id` contract to hold it to, and `outputs/` pages are written by
+  // /lumi-ask under a convention nothing enforces.
+  const entityType = entityTypeForPath(wikiRelPath);
+  if (!entityType || !REQUIRED_FRONTMATTER[entityType]) return [];
+  const raw = fm.id;
+  if (typeof raw !== 'string') return []; // missing or mistyped: L01/L02 own it.
+  const actual = raw.trim();
+  if (actual === '' || actual === 'TODO') return []; // likewise.
+
+  const expected = deriveIdFromPath(wikiRelPath, null);
+  if (actual === expected) return [];
+
+  // `id: concepts/ab-testing` on a flat type is the pre-v0.1 `slug` -> `id`
+  // migration's own output: it carries strictly more information than the bare
+  // id, never less, and `--fix` deliberately never rewrites it back. One real
+  // 813-page wiki held 179 of them. Not a mismatch.
+  const slash = actual.indexOf('/');
+  if (slash > 0
+    && actual.slice(slash + 1) === expected
+    && Object.prototype.hasOwnProperty.call(ENTITY_DIRS, actual.slice(0, slash))) {
+    return [];
+  }
+
+  return [finding(
+    'L18-id-filename-mismatch', 'warning', false,
+    wikiRelPath, null,
+    `Frontmatter id "${actual}" does not name this file; the path derives "${expected}"`
+  )];
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // FIXERS
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1934,42 +1984,223 @@ async function fixL02(absPath, wikiRelPath, content, l02findings, edges, knownSl
 }
 
 /**
- * Fixer for L03: rename file to kebab-case + rewrite all wikilinks pointing to old slug.
- * Returns a list of { from, to, newContent } operations.
- * @param {string} wikiRelPath
+ * Plan the L03 renames — pure path work plus one existence probe each, no
+ * mutation.
+ *
+ * Separated from the apply step because the plan has to be known BEFORE fixL05
+ * runs: fixL05 deliberately leaves alone any link pointing at a file L03 is
+ * about to rename, so that fixL03's bare-form rewrite can handle it in the same
+ * pass. Deciding the plan later meant that skip applied to files that turned
+ * out never to move, leaving those links unrepaired for as long as whatever
+ * blocked the rename lasted.
+ *
+ * A finding this run will not act on carries the reason in `renameBlocked`,
+ * which `computeSuggestion` turns into advice; it is never marked fixed.
+ * @param {Finding[]} l03findings
  * @param {string} wikiRoot  Absolute wiki dir.
- * @param {string[]} allMdFiles  Absolute paths of all .md files.
- * @returns {Promise<Array<{absPath:string, newContent:string|null, newPath:string|null}>>}
+ * @returns {Promise<Array<{finding:Finding, relPath:string, newRelPath:string, absOld:string, absNew:string, oldSlug:string, newSlug:string}>>}
  */
-async function fixL03(wikiRelPath, wikiRoot, allMdFiles) {
-  const base = basename(wikiRelPath, '.md');
-  const kebab = base
-    .toLowerCase()
-    .replace(/[\s_]+/g, '-')
-    .replace(/[^a-z0-9-]/g, '')
-    .replace(/^-+|-+$/g, '');
+async function planL03(l03findings, wikiRoot) {
+  const plans = [];
+  const claimedBy = new Map(); // absNew -> the plan that already claims it
+  for (const f of l03findings) {
+    const relPath = f.file;
+    const oldSlug = basename(relPath, '.md');
+    // The shared slugify, not a second hand-written kebab transform: the old
+    // local copy skipped NFD entirely and deleted every non-ASCII character
+    // instead of decomposing it, so `lint --fix` renamed `Nhà-Nguyễn.md` to
+    // `nh-nguyn.md` — a name `wiki.mjs slug` would never produce for the same
+    // title, and one no reader can recognise.
+    const newSlug = slugify(oldSlug);
 
-  const oldSlug = base;
-  const newSlug = kebab;
-  if (oldSlug === newSlug) return [];
+    if (newSlug === '') {
+      // e.g. "___.md" or "!!!.md". The old code renamed these to ".md": a
+      // dotfile with an empty basename, i.e. the page silently left the wiki.
+      f.renameBlocked = `"${oldSlug}" has no kebab-case form — every character is punctuation, so there would be no filename left. Rename it by hand.`;
+      continue;
+    }
+    if (newSlug === oldSlug) continue; // already kebab; checkL03 cannot flag this, guard anyway.
 
-  const ops = [];
-  const absOld = safejoin(wikiRoot, wikiRelPath);
-  const absNew = safejoin(wikiRoot, dirname(wikiRelPath), newSlug + '.md');
-  ops.push({ absPath: absOld, newContent: null, newPath: absNew });
+    const absOld = safejoin(wikiRoot, relPath);
+    const newRelPath = join(dirname(relPath), newSlug + '.md').replace(/\\/g, '/');
+    const absNew = safejoin(wikiRoot, newRelPath);
 
-  // Rewrite wikilinks in all other files.
-  for (const f of allMdFiles) {
-    if (f === absOld) continue;
-    const fc = await readFile(f, 'utf8');
-    if (fc.includes(`[[${oldSlug}]]`) || fc.includes(`[[${oldSlug}|`)) {
-      const updated = fc
-        .replace(new RegExp(`\\[\\[${escapeRegex(oldSlug)}(\\|[^\\]]*)?\\]\\]`, 'g'),
-          (_, alias) => `[[${newSlug}${alias || ''}]]`);
-      ops.push({ absPath: f, newContent: updated, newPath: null });
+    const claimed = claimedBy.get(absNew);
+    if (claimed) {
+      f.renameBlocked = `"${oldSlug}" and "${claimed.oldSlug}" both kebab-case to "${newSlug}" — renaming both would leave one page on top of the other. Rename one of them by hand first.`;
+      continue;
+    }
+    if (await occupiedByAnotherFile(absNew, absOld)) {
+      f.renameBlocked = `"${newSlug}.md" already exists in the same directory — renaming would overwrite it and lose its contents. Merge the two pages, or rename one by hand.`;
+      continue;
+    }
+
+    const plan = { finding: f, relPath, newRelPath, absOld, absNew, oldSlug, newSlug };
+    claimedBy.set(absNew, plan);
+    plans.push(plan);
+  }
+  return plans;
+}
+
+/**
+ * True when `absNew` already holds a file that is not `absOld` itself.
+ *
+ * `rename()` overwrites its destination without a word, so this is the only
+ * thing standing between a slug collision and a page that is simply gone.
+ * The identity check matters on case-insensitive filesystems (macOS by
+ * default), where a case-only rename finds its own source sitting at the
+ * destination path — same inode, not a collision.
+ * @param {string} absNew
+ * @param {string} absOld
+ * @returns {Promise<boolean>}
+ */
+async function occupiedByAnotherFile(absNew, absOld) {
+  let dest;
+  try {
+    dest = await stat(absNew);
+  } catch {
+    return false; // nothing there — the rename is free to proceed.
+  }
+  try {
+    const source = await stat(absOld);
+    if (source.ino === dest.ino && source.dev === dest.dev) return false;
+  } catch {
+    // Source unreadable: refuse rather than guess.
+  }
+  return true;
+}
+
+/**
+ * Fixer for L03: rename each planned file to its kebab-case name, then repair
+ * every wikilink that pointed at it and the `id`/`slug` frontmatter of the
+ * pages that moved.
+ *
+ * One pass over the wiki for all renames together. The previous shape re-read
+ * every page once per finding, against a file list captured before any rename
+ * had happened — which cost O(findings x pages) full reads and, worse, threw
+ * ENOENT and aborted the entire `--fix` run (exit 3, no JSON on stdout, wiki
+ * left half-repaired) the moment a second finding reached a path the first had
+ * already renamed away.
+ * @param {Array<object>} plans  Output of planL03.
+ * @param {string[]} allMdFiles  Absolute paths of all .md files, pre-rename.
+ * @param {{dryRun?: boolean}} opts
+ * @returns {Promise<Array<object>>}  The plans whose rename actually happened.
+ */
+async function fixL03(plans, allMdFiles, opts) {
+  if (plans.length === 0) return [];
+
+  // Keyed by old basename, which two plans in different directories can share:
+  // both rewrite `[[Foo_Bar]]` to the same thing, so the replacement runs once
+  // and every plan that asked for it gets the credit.
+  const bySlug = new Map();
+  for (const p of plans) {
+    if (!bySlug.has(p.oldSlug)) bySlug.set(p.oldSlug, { newSlug: p.newSlug, plans: [] });
+    bySlug.get(p.oldSlug).plans.push(p);
+  }
+  const planByAbsOld = new Map(plans.map(p => [p.absOld, p]));
+  const rewrittenBy = new Map(plans.map(p => [p.finding, []])); // finding -> abs paths it changes
+
+  const renamed = [];
+  if (!opts.dryRun) {
+    for (const p of plans) {
+      try {
+        await rename(p.absOld, p.absNew);
+        renamed.push(p);
+      } catch (err) {
+        // One unwritable file must not cost the caller the whole report: the
+        // old code let this escape, and runLint's caller turns any throw into
+        // exit 3 with nothing on stdout, stranding the wiki half-repaired.
+        p.finding.renameBlocked = `Could not rename to "${p.newSlug}.md": ${err.message}`;
+        planByAbsOld.delete(p.absOld);
+        for (const entry of bySlug.values()) {
+          entry.plans = entry.plans.filter(q => q !== p);
+        }
+      }
+    }
+    for (const [slug, entry] of bySlug) {
+      if (entry.plans.length === 0) bySlug.delete(slug);
+    }
+  } else {
+    renamed.push(...plans);
+  }
+
+  for (const abs of allMdFiles) {
+    const moved = planByAbsOld.get(abs);
+    // After the renames above, a moved page only exists at its new path.
+    const current = (moved && !opts.dryRun) ? moved.absNew : abs;
+    let content;
+    try {
+      content = await readFile(current, 'utf8');
+    } catch {
+      continue; // vanished under us (concurrent edit) — nothing to repair here.
+    }
+
+    let updated = content;
+    for (const [oldSlug, entry] of bySlug) {
+      if (!updated.includes(`[[${oldSlug}]]`) && !updated.includes(`[[${oldSlug}|`)) continue;
+      updated = updated.replace(
+        new RegExp(`\\[\\[${escapeRegex(oldSlug)}(\\|[^\\]]*)?\\]\\]`, 'g'),
+        (_, alias) => `[[${entry.newSlug}${alias || ''}]]`,
+      );
+      for (const p of entry.plans) rewrittenBy.get(p.finding).push(current);
+    }
+    if (moved) updated = retargetIdAfterRename(updated, moved);
+
+    if (updated !== content && !opts.dryRun) await atomicWrite(current, updated);
+  }
+
+  for (const p of renamed) {
+    if (opts.dryRun) {
+      p.finding.proposed_fix = [
+        `rename: ${p.absOld} -> ${p.absNew}`,
+        ...rewrittenBy.get(p.finding).map(abs => `rewrite wikilinks in: ${abs}`),
+      ].join('\n');
+    } else {
+      p.finding.fix_applied = true;
     }
   }
-  return ops;
+  return renamed;
+}
+
+/**
+ * Point a moved page's own `id` (and legacy `slug`) at its new filename.
+ *
+ * Renaming the file without this left the frontmatter naming a path that no
+ * longer existed — and invisibly, because L03 stops firing the instant the
+ * basename is kebab-case, and no other check compares the two. Only a value
+ * that still matches what the OLD path derives is rewritten; an id the author
+ * chose deliberately is left alone.
+ * @param {string} content
+ * @param {{relPath:string, newRelPath:string}} plan
+ * @returns {string}
+ */
+function retargetIdAfterRename(content, plan) {
+  const parsed = parseFrontmatter(content);
+  if (!parsed) return content;
+
+  const oldId = deriveIdFromPath(plan.relPath, null);
+  const newId = deriveIdFromPath(plan.newRelPath, null);
+  if (oldId === newId) return content;
+
+  let fmText = parsed.fmText;
+  let changed = false;
+  for (const key of ['id', 'slug']) {
+    const val = parsed.data[key];
+    if (typeof val !== 'string') continue;
+    // The `<entity-dir>/<slug>` shape the pre-v0.1 slug->id migration leaves
+    // behind is just as much a name for this file as the bare one, and keeping
+    // its prefix is what stops the rename from stranding it.
+    const actual = val.trim();
+    let next = null;
+    if (actual === oldId) next = newId;
+    else if (actual.endsWith(`/${oldId}`) && Object.prototype.hasOwnProperty.call(ENTITY_DIRS, actual.slice(0, actual.length - oldId.length - 1))) {
+      next = `${actual.slice(0, actual.length - oldId.length - 1)}/${newId}`;
+    }
+    if (next === null) continue;
+    fmText = replaceFrontmatterKeyLines(fmText, key, renderYamlLine(key, next));
+    changed = true;
+  }
+  return changed ? `---\n${fmText}${parsed.tail}` : content;
 }
 
 function escapeRegex(s) {
@@ -2233,6 +2464,7 @@ async function runLint(projectRoot, opts) {
     allFindings.push(...checkL13(wikiRelPath, fm));
     allFindings.push(...checkL14(wikiRelPath, fm));
     allFindings.push(...checkL16(wikiRelPath, fm));
+    allFindings.push(...checkL18(wikiRelPath, fm));
   }
 
   allFindings.push(...checkL06(edges, new Set(edgeSet)));
@@ -2370,9 +2602,8 @@ async function applyFixes(findings, wikiRoot, edgesPath, indexPath, indexContent
   // fixL03 rewrite the bare link correctly in this same run; whatever prefix is
   // still missing afterwards is picked up by the next run, with no page left
   // pointing at a file that never existed.
-  const pendingRenames = new Set(
-    findings.filter(f => f.id === 'L03-slug-style').map(f => f.file.replace(/\.md$/, ''))
-  );
+  const l03plans = await planL03(findings.filter(f => f.id === 'L03-slug-style'), wikiRoot);
+  const pendingRenames = new Set(l03plans.map(p => p.relPath.replace(/\.md$/, '')));
   const l05ByFile = new Map();
   for (const f of findings.filter(f => f.id === 'L05-broken-wikilink')) {
     if (!l05ByFile.has(f.file)) l05ByFile.set(f.file, []);
@@ -2396,24 +2627,14 @@ async function applyFixes(findings, wikiRoot, edgesPath, indexPath, indexContent
     }
   }
 
-  // Fix L03.
-  const l03findings = findings.filter(f => f.id === 'L03-slug-style');
-  for (const f of l03findings) {
-    const ops = await fixL03(f.file, wikiRoot, allAbsMd);
-    if (opts.dryRun) {
-      f.proposed_fix = ops.map(op => op.newPath
-        ? `rename: ${op.absPath} -> ${op.newPath}`
-        : `rewrite wikilinks in: ${op.absPath}`
-      ).join('\n');
-    } else {
-      for (const op of ops) {
-        if (op.newPath) {
-          await rename(op.absPath, op.newPath);
-        } else if (op.newContent !== null) {
-          await atomicWrite(op.absPath, op.newContent);
-        }
-      }
-      f.fix_applied = true;
+  // Fix L03 (planned above, before fixL05, so its skip list is accurate).
+  const l03renamed = await fixL03(l03plans, allAbsMd, opts);
+  // L09 renders the index from `entityFiles`, captured before the renames
+  // above. Left stale it would list a page under the name it no longer has.
+  if (!opts.dryRun) {
+    for (const p of l03renamed) {
+      const i = entityFiles.indexOf(p.relPath);
+      if (i !== -1) entityFiles[i] = p.newRelPath;
     }
   }
 
@@ -2477,6 +2698,14 @@ function computeSuggestion(f) {
     }
     if (f.todoPlaceholder) return `${f.key}: currently "TODO" — no automatic derivation exists for this field; provide a real value manually.`;
     if (f.key && f.expected) return `${f.key}: expected ${f.expected}, cannot be safely inferred — provide a value manually.`;
+  }
+
+  if (f.id === 'L18-id-filename-mismatch') {
+    return 'Set `id` to the value the path derives, or rename the file to match the id — whichever of the two is the one you meant. Nothing resolves pages by id, so neither is urgent.';
+  }
+
+  if (f.id === 'L03-slug-style' && f.renameBlocked) {
+    return f.renameBlocked;
   }
 
   if (f.id === 'L05-broken-wikilink') {
@@ -2580,14 +2809,16 @@ function reportJson(findings, scannedFiles, opts = {}) {
   const fixes = findings.filter(f => f.fix_applied).length;
 
   // Strip internal-only fields from the public shape: candidates/brokenSlug/
-  // suppressedRepair (checkL05, for fixL05 and computeSuggestion) and
+  // suppressedRepair (checkL05, for fixL05 and computeSuggestion),
   // key/fieldType/expected/todoPlaceholder/legacyOldKey/legacyNewKey (checkL01
-  // and checkL02, for their fixers and computeSuggestion). `candidates` and
+  // and checkL02, for their fixers and computeSuggestion), and renameBlocked
+  // (planL03, whose user-facing form is the suggestion). `candidates` and
   // the `suggestion` key are re-added only when --suggest was requested.
   const outputFindings = findings.map(f => {
     const {
       candidates, brokenSlug, suppressedRepair,
       key, fieldType, expected, todoPlaceholder, legacyOldKey, legacyNewKey,
+      renameBlocked,
       ...rest
     } = f;
     if (opts.suggest) {
@@ -2715,8 +2946,8 @@ export {
   entityTypeForPath,
   checkL01, checkL02, checkL03, checkL04, checkL05,
   checkL06, checkL07, checkL08, checkL09, checkL10, checkL11, checkL12,
-  checkL13, checkL14, checkL16, checkL17,
-  fixL01, fixL02, fixL03, fixL05, fixL06, fixL07, fixL09,
+  checkL13, checkL14, checkL16, checkL17, checkL18,
+  fixL01, fixL02, planL03, fixL03, fixL05, fixL06, fixL07, fixL09,
   runLint,
   reportSummary,
   reportHuman,

--- a/src/scripts/lint.mjs
+++ b/src/scripts/lint.mjs
@@ -1778,10 +1778,21 @@ function checkL18(wikiRelPath, fm) {
   // migration's own output: it carries strictly more information than the bare
   // id, never less, and `--fix` deliberately never rewrites it back. One real
   // 813-page wiki held 179 of them. Not a mismatch.
+  //
+  // The migration only ever prefixed a page with ITS OWN entity dir — it never
+  // produced `sources/foo` for a page that actually lives in `concepts/` — so
+  // the prefix must equal this page's own `entityType`, not merely be some
+  // other recognized dir name. And it only ever ran against flat entity types:
+  // a nested type's expected id is already the full wiki-relative path (or
+  // `reflection-<name>`), so any prefix in front of that is not the legacy
+  // shape at all, just a second, unrelated mismatch the exemption would
+  // otherwise hide.
+  const isFlatEntity = entityType !== 'reflections' && !NESTED_ID_ENTITY_DIRS.has(entityType);
   const slash = actual.indexOf('/');
-  if (slash > 0
+  if (isFlatEntity
+    && slash > 0
     && actual.slice(slash + 1) === expected
-    && Object.prototype.hasOwnProperty.call(ENTITY_DIRS, actual.slice(0, slash))) {
+    && actual.slice(0, slash) === entityType) {
     return [];
   }
 
@@ -2635,6 +2646,35 @@ async function applyFixes(findings, wikiRoot, edgesPath, indexPath, indexContent
     for (const p of l03renamed) {
       const i = entityFiles.indexOf(p.relPath);
       if (i !== -1) entityFiles[i] = p.newRelPath;
+    }
+
+    // L18 was checked against each page's pre-rename path and frontmatter, so
+    // a renamed page's finding (if any) is keyed to a file that no longer
+    // exists. Worse, the rename above — via retargetIdAfterRename — can have
+    // already resolved the very mismatch it reported (e.g. `Foo_Bar.md` with
+    // `id: foo-bar` renames to `foo-bar.md`, which now agrees). Left alone,
+    // that stale finding survives as a false unresolved warning even though
+    // this same `--fix` run already fixed it, and only an immediate second
+    // run would come back clean. Drop the stale finding and recheck the new
+    // path against the file's current (possibly retargeted) content so the
+    // report matches what is actually on disk after this run.
+    if (l03renamed.length > 0) {
+      const renamedRelPaths = new Set(l03renamed.map(p => p.relPath));
+      for (let i = findings.length - 1; i >= 0; i--) {
+        if (findings[i].id === 'L18-id-filename-mismatch' && renamedRelPaths.has(findings[i].file)) {
+          findings.splice(i, 1);
+        }
+      }
+      for (const p of l03renamed) {
+        let content;
+        try {
+          content = await readFile(safejoin(wikiRoot, p.newRelPath), 'utf8');
+        } catch {
+          continue; // vanished under us (concurrent edit) — nothing to recheck.
+        }
+        const parsed = parseFrontmatter(content);
+        findings.push(...checkL18(p.newRelPath, parsed ? parsed.data : {}));
+      }
     }
   }
 

--- a/src/scripts/lint.test.mjs
+++ b/src/scripts/lint.test.mjs
@@ -23,7 +23,7 @@ import {
   entityTypeForPath,
   checkL01, checkL02, checkL03, checkL04, checkL05,
   checkL06, checkL07, checkL08, checkL09, checkL10, checkL11, checkL12,
-  checkL13, checkL14, checkL16, checkL17,
+  checkL13, checkL14, checkL16, checkL17, checkL18,
   fixL01, fixL02, fixL05, fixL06, fixL07, fixL09,
   reconstructArrayFromBody,
   runLint,
@@ -2326,6 +2326,292 @@ describe('runLint L03 fix', () => {
     const goodPath = join(tmpDir, 'wiki', 'sources', 'mypaper.md');
     const goodContent = await readFile(goodPath, 'utf8');
     assert.ok(goodContent.length > 0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// REGRESSION: L03 slug-rename fixer data-loss / crash fixes
+// (planL03, occupiedByAnotherFile, fixL03, retargetIdAfterRename) + new L18
+// id-filename-mismatch check. Covers: destination-exists collision (a),
+// same-target collision between two flagged files + crash safety (b),
+// accented-basename transliteration via the shared slugify (c), empty-slug
+// refusal (d), frontmatter id retargeting incl. the legacy dir-qualified
+// shape (e), checkL18 itself (f), and --dry-run on a refused rename (g).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('runLint L03 fix: destination-exists collision', () => {
+  test('rename is refused when the kebab target already exists; nothing is lost', async () => {
+    const tmp = await makeTmp();
+    try {
+      await makeWiki(tmp);
+      const preexistingContent = renderFm(validSourceFm({ id: 'foo-bar', title: 'Foo Bar' })) + 'PREEXISTING BODY MARKER.';
+      await writeFile(join(tmp, 'wiki', 'sources', 'foo-bar.md'), preexistingContent);
+      await writeFile(join(tmp, 'wiki', 'sources', 'Foo_Bar.md'),
+        renderFm(validSourceFm({ id: 'Foo_Bar', title: 'Foo Bar Bad Case' })) + 'BAD CASE BODY MARKER.');
+
+      const result = await runLint(tmp, { fix: true, dryRun: false });
+
+      // Both files must survive the run.
+      await access(join(tmp, 'wiki', 'sources', 'foo-bar.md'), fsConstants.F_OK);
+      await access(join(tmp, 'wiki', 'sources', 'Foo_Bar.md'), fsConstants.F_OK);
+
+      // The pre-existing page must be byte-for-byte untouched — not silently
+      // overwritten by an unconditional rename() onto its destination.
+      const afterContent = await readFile(join(tmp, 'wiki', 'sources', 'foo-bar.md'), 'utf8');
+      assert.equal(afterContent, preexistingContent, 'the pre-existing page must not be overwritten by the blocked rename');
+
+      const l03 = result.findings.find(f => f.id === 'L03-slug-style' && f.file === 'sources/Foo_Bar.md');
+      assert.ok(l03, 'expected an L03 finding for Foo_Bar.md');
+      assert.ok(!l03.fix_applied, 'fix_applied must be falsy: the rename was refused, not performed');
+      assert.equal(l03.fixable, false, 'fixable must be corrected to false once applyFixes sees nothing was actually fixed');
+    } finally {
+      await removeTmp(tmp);
+    }
+  });
+});
+
+describe('runLint L03 fix: two findings collide on the same target slug', () => {
+  test('run completes without crashing; no content lost; an unrelated third file still gets renamed', async () => {
+    const tmp = await makeTmp();
+    try {
+      await makeWiki(tmp);
+      const markerOne = 'COLLISION BODY ONE MARKER.';
+      const markerTwo = 'COLLISION BODY TWO MARKER.';
+      // Two DIFFERENT basenames (differ by more than case: underscore vs.
+      // space) that both kebab-case to "foo-bar" — chosen so the pair is
+      // still two distinct files on a case-insensitive filesystem (macOS
+      // default), unlike a pure-case variant such as "Foo_Bar"/"foo_bar".
+      await writeFile(join(tmp, 'wiki', 'sources', 'Foo_Bar.md'),
+        renderFm(validSourceFm({ id: 'Foo_Bar', title: 'Foo Bar One' })) + markerOne);
+      await writeFile(join(tmp, 'wiki', 'sources', 'Foo Bar.md'),
+        renderFm(validSourceFm({ id: 'Foo Bar', title: 'Foo Bar Two' })) + markerTwo);
+      // Unrelated third L03 finding in a different directory, colliding with
+      // nothing. This is what the ENOENT crash used to make unreachable: the
+      // old fixL03 re-read every file in a pre-rename snapshot with no
+      // try/catch, so as soon as ANY earlier finding in the same run had
+      // renamed a file away, the next finding's pass threw and aborted the
+      // whole run (exit 3, zero bytes on stdout) before this file's turn.
+      await writeFile(join(tmp, 'wiki', 'concepts', 'MyConcept.md'),
+        `---\nid: MyConcept\ntitle: My Concept\ntype: concept\ncreated: 2026-01-01\nupdated: 2026-01-01\nkey_sources: []\nrelated_concepts: []\n---\nUNRELATED CONCEPT BODY.`);
+
+      // Must not throw/reject.
+      const result = await runLint(tmp, { fix: true, dryRun: false });
+
+      const readIfExists = async (p) => { try { return await readFile(p, 'utf8'); } catch { return null; } };
+      const winner = await readIfExists(join(tmp, 'wiki', 'sources', 'foo-bar.md'));
+      const loserA = await readIfExists(join(tmp, 'wiki', 'sources', 'Foo_Bar.md'));
+      const loserB = await readIfExists(join(tmp, 'wiki', 'sources', 'Foo Bar.md'));
+
+      // Exactly one of the two colliding files was renamed to the shared
+      // target; the other was left exactly where it was. Which one wins is
+      // not guaranteed (finding order), so only the aggregate is checked.
+      assert.ok(winner, 'expected exactly one of the colliding files to have been renamed to foo-bar.md');
+      const survivors = [winner, loserA, loserB].filter(Boolean);
+      assert.equal(survivors.length, 2, 'both original files must still exist on disk in some form');
+
+      // Neither body was lost, regardless of which file won the rename.
+      const allBodies = survivors.join('\n');
+      assert.ok(allBodies.includes(markerOne), 'first colliding page body must survive');
+      assert.ok(allBodies.includes(markerTwo), 'second colliding page body must survive');
+
+      // The unrelated third file, in a different directory, still got
+      // renamed in this same run — proof the crash did not abort the loop.
+      await access(join(tmp, 'wiki', 'concepts', 'myconcept.md'), fsConstants.F_OK);
+      const conceptFinding = result.findings.find(f => f.id === 'L03-slug-style' && f.file === 'concepts/MyConcept.md');
+      assert.ok(conceptFinding, 'expected an L03 finding for MyConcept.md');
+      assert.ok(conceptFinding.fix_applied, 'the unrelated file must still be renamed even though two other findings collided');
+
+      // Exactly one of the two colliding findings actually got fixed.
+      const collisionFindings = result.findings.filter(f => f.id === 'L03-slug-style'
+        && (f.file === 'sources/Foo_Bar.md' || f.file === 'sources/Foo Bar.md'));
+      assert.equal(collisionFindings.length, 2, 'expected one L03 finding per colliding file');
+      assert.equal(collisionFindings.filter(f => f.fix_applied).length, 1, 'exactly one of the two colliding renames must succeed');
+    } finally {
+      await removeTmp(tmp);
+    }
+  });
+});
+
+describe('runLint L03 fix: accented basename transliteration', () => {
+  test('renames via the shared slugify (NFD decompose), and rewrites a bare wikilink elsewhere', async () => {
+    const tmp = await makeTmp();
+    try {
+      await makeWiki(tmp);
+      const fm = renderFm(validSourceFm({ id: 'nha-nguyen-source', title: 'Nhà Nguyễn' }));
+      await writeFile(join(tmp, 'wiki', 'sources', 'Nhà-Nguyễn.md'), fm + 'Body about the Nguyen dynasty.');
+
+      const otherFm = renderFm(validSourceFm({ id: 'other-page', title: 'Other Page' }));
+      await writeFile(join(tmp, 'wiki', 'sources', 'other-page.md'),
+        otherFm + 'See [[Nhà-Nguyễn]] for background.');
+
+      const result = await runLint(tmp, { fix: true, dryRun: false });
+
+      // Old filename gone.
+      try {
+        await access(join(tmp, 'wiki', 'sources', 'Nhà-Nguyễn.md'), fsConstants.F_OK);
+        assert.fail('accented bad-case file should have been renamed away');
+      } catch {
+        // expected
+      }
+      // Transliterated filename present — NOT the old "nh-nguyn" that a
+      // non-decomposing, ASCII-stripping kebab transform would have produced.
+      const renamedContent = await readFile(join(tmp, 'wiki', 'sources', 'nha-nguyen.md'), 'utf8');
+      assert.ok(renamedContent.length > 0);
+
+      const l03 = result.findings.find(f => f.id === 'L03-slug-style' && f.file === 'sources/Nhà-Nguyễn.md');
+      assert.ok(l03 && l03.fix_applied, 'expected the accented-file L03 finding to be fixed');
+
+      // The wikilink on the OTHER page must be rewritten to the same
+      // transliterated slug.
+      const otherContent = await readFile(join(tmp, 'wiki', 'sources', 'other-page.md'), 'utf8');
+      assert.ok(otherContent.includes('[[nha-nguyen]]'), `expected the wikilink rewritten to [[nha-nguyen]], got:\n${otherContent}`);
+      assert.ok(!otherContent.includes('[[Nhà-Nguyễn]]'), 'the old broken link text must not remain');
+    } finally {
+      await removeTmp(tmp);
+    }
+  });
+});
+
+describe('runLint L03 fix: empty-slug basename is refused', () => {
+  test('a basename that kebab-cases to the empty string is left alone', async () => {
+    const tmp = await makeTmp();
+    try {
+      await makeWiki(tmp);
+      const fm = renderFm(validSourceFm({ id: '___', title: 'All Punctuation' }));
+      await writeFile(join(tmp, 'wiki', 'sources', '___.md'), fm + 'Body.');
+
+      const result = await runLint(tmp, { fix: true, dryRun: false });
+
+      // The file must still exist under its original name.
+      const content = await readFile(join(tmp, 'wiki', 'sources', '___.md'), 'utf8');
+      assert.ok(content.includes('Body.'));
+
+      // Nothing was created at the degenerate ".md" destination the old
+      // code (rename to `newSlug + '.md'` with newSlug === '') used to produce.
+      try {
+        await access(join(tmp, 'wiki', 'sources', '.md'), fsConstants.F_OK);
+        assert.fail('must not have created a bare ".md" file');
+      } catch {
+        // expected
+      }
+
+      const l03 = result.findings.find(f => f.id === 'L03-slug-style' && f.file === 'sources/___.md');
+      assert.ok(l03, 'expected an L03 finding for ___.md');
+      assert.ok(!l03.fix_applied, 'fix_applied must be falsy');
+      assert.equal(l03.fixable, false, 'fixable must be corrected to false: there is no kebab-case form to rename to');
+    } finally {
+      await removeTmp(tmp);
+    }
+  });
+});
+
+describe('runLint L03 fix: frontmatter id is retargeted after rename', () => {
+  test('bare id matching the old basename is updated to the new one', async () => {
+    const tmp = await makeTmp();
+    try {
+      await makeWiki(tmp);
+      const fm = renderFm(validSourceFm({ id: 'Bad_Case', title: 'Bad Case' }));
+      await writeFile(join(tmp, 'wiki', 'sources', 'Bad_Case.md'), fm + 'Body.');
+
+      await runLint(tmp, { fix: true, dryRun: false });
+
+      const content = await readFile(join(tmp, 'wiki', 'sources', 'bad-case.md'), 'utf8');
+      const parsed = parseFrontmatter(content);
+      assert.ok(parsed);
+      assert.equal(parsed.data.id, 'bad-case', `expected id retargeted to the new filename, got:\n${content}`);
+    } finally {
+      await removeTmp(tmp);
+    }
+  });
+
+  test('legacy dir-qualified id ("concepts/Foo_Bar") keeps its prefix and follows the rename', async () => {
+    const tmp = await makeTmp();
+    try {
+      await makeWiki(tmp);
+      const fm = `---\nid: concepts/Foo_Bar\ntitle: Foo Bar Concept\ntype: concept\ncreated: 2026-01-01\nupdated: 2026-01-01\nkey_sources: []\nrelated_concepts: []\n---\n`;
+      await writeFile(join(tmp, 'wiki', 'concepts', 'Foo_Bar.md'), fm + 'Body.');
+
+      await runLint(tmp, { fix: true, dryRun: false });
+
+      const content = await readFile(join(tmp, 'wiki', 'concepts', 'foo-bar.md'), 'utf8');
+      const parsed = parseFrontmatter(content);
+      assert.ok(parsed);
+      assert.equal(parsed.data.id, 'concepts/foo-bar', `expected the legacy prefix preserved across the rename, got:\n${content}`);
+    } finally {
+      await removeTmp(tmp);
+    }
+  });
+});
+
+describe('checkL18 id-filename-mismatch', () => {
+  test('flags a genuine mismatch', () => {
+    const result = checkL18('sources/foo-bar.md', { id: 'something-else' });
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, 'L18-id-filename-mismatch');
+    assert.equal(result[0].severity, 'warning');
+    assert.equal(result[0].fixable, false);
+    assert.ok(result[0].message.includes('something-else'));
+    assert.ok(result[0].message.includes('foo-bar'));
+  });
+
+  test('does not flag: bare basename on a flat dir', () => {
+    assert.equal(checkL18('sources/foo-bar.md', { id: 'foo-bar' }).length, 0);
+  });
+
+  test('does not flag: full wiki-relative path on a nested dir (readings/)', () => {
+    assert.equal(checkL18('readings/deep-work/01-focus.md', { id: 'readings/deep-work/01-focus' }).length, 0);
+  });
+
+  test('does not flag: "reflection-<name>" under reflections/', () => {
+    assert.equal(checkL18('reflections/my-note.md', { id: 'reflection-my-note' }).length, 0);
+  });
+
+  test('does not flag: legacy "concepts/<name>" shape on a flat dir', () => {
+    assert.equal(checkL18('concepts/ab-testing.md', { id: 'concepts/ab-testing' }).length, 0);
+  });
+
+  test('does not flag a file with no id contract: index.md, graph/, outputs/', () => {
+    assert.equal(checkL18('index.md', { id: 'anything-at-all' }).length, 0);
+    assert.equal(checkL18('log.md', { id: 'anything-at-all' }).length, 0);
+    assert.equal(checkL18('graph/notes.md', { id: 'anything-at-all' }).length, 0);
+    // outputs/ pages carry an id by /lumi-ask convention, but no schema
+    // declares one, so L18 has nothing to hold them to.
+    assert.equal(checkL18('outputs/answer.md', { id: 'anything-at-all' }).length, 0);
+  });
+
+  test('leaves a missing or TODO id to L01/L02 rather than reporting it twice', () => {
+    assert.equal(checkL18('sources/foo-bar.md', {}).length, 0);
+    assert.equal(checkL18('sources/foo-bar.md', { id: 'TODO' }).length, 0);
+    assert.equal(checkL18('sources/foo-bar.md', { id: '   ' }).length, 0);
+    assert.equal(checkL18('sources/foo-bar.md', { id: 42 }).length, 0);
+  });
+});
+
+describe('runLint L03 fix: --dry-run on a refused rename', () => {
+  test('writes nothing and does not set proposed_fix on the refused finding', async () => {
+    const tmp = await makeTmp();
+    try {
+      await makeWiki(tmp);
+      const preexistingContent = renderFm(validSourceFm({ id: 'foo-bar', title: 'Foo Bar' })) + 'PREEXISTING BODY MARKER.';
+      await writeFile(join(tmp, 'wiki', 'sources', 'foo-bar.md'), preexistingContent);
+      const badContent = renderFm(validSourceFm({ id: 'Foo_Bar', title: 'Foo Bar Bad Case' })) + 'BAD CASE BODY MARKER.';
+      await writeFile(join(tmp, 'wiki', 'sources', 'Foo_Bar.md'), badContent);
+
+      const result = await runLint(tmp, { fix: true, dryRun: true });
+
+      const afterGood = await readFile(join(tmp, 'wiki', 'sources', 'foo-bar.md'), 'utf8');
+      const afterBad = await readFile(join(tmp, 'wiki', 'sources', 'Foo_Bar.md'), 'utf8');
+      assert.equal(afterGood, preexistingContent, 'dry-run must not write to the pre-existing file');
+      assert.equal(afterBad, badContent, 'dry-run must not write to the blocked source file either');
+
+      const l03 = result.findings.find(f => f.id === 'L03-slug-style' && f.file === 'sources/Foo_Bar.md');
+      assert.ok(l03, 'expected an L03 finding for Foo_Bar.md');
+      assert.ok(!l03.proposed_fix, 'a refused rename must not preview a proposed_fix — there is nothing safe to preview');
+      assert.ok(!l03.fix_applied, 'dry-run must never set fix_applied');
+      assert.equal(l03.fixable, false, 'fixable must be corrected to false since dry-run resolved nothing for this finding');
+    } finally {
+      await removeTmp(tmp);
+    }
   });
 });
 

--- a/src/scripts/lint.test.mjs
+++ b/src/scripts/lint.test.mjs
@@ -2570,6 +2570,26 @@ describe('checkL18 id-filename-mismatch', () => {
     assert.equal(checkL18('concepts/ab-testing.md', { id: 'concepts/ab-testing' }).length, 0);
   });
 
+  test('flags a legacy-shaped id whose prefix names a different entity dir than this page\'s own', () => {
+    // `concepts/foo.md` claiming `id: sources/foo` names the wrong page
+    // type. The legacy-shape exemption must require the prefix to equal
+    // THIS page's own entity dir, not merely be some other ENTITY_DIRS key.
+    const result = checkL18('concepts/foo.md', { id: 'sources/foo' });
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, 'L18-id-filename-mismatch');
+    assert.ok(result[0].message.includes('sources/foo'));
+  });
+
+  test('flags a nested-dir id carrying an extra recognized-but-wrong prefix', () => {
+    // The legacy `<entity-dir>/<slug>` shape only ever applied to FLAT
+    // entity types. A nested type's own id is already the full
+    // wiki-relative path, so a prefix in front of that is a second,
+    // unrelated mismatch, not the legacy migration's output.
+    const result = checkL18('readings/deep-work/01-focus.md', { id: 'sources/readings/deep-work/01-focus' });
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, 'L18-id-filename-mismatch');
+  });
+
   test('does not flag a file with no id contract: index.md, graph/, outputs/', () => {
     assert.equal(checkL18('index.md', { id: 'anything-at-all' }).length, 0);
     assert.equal(checkL18('log.md', { id: 'anything-at-all' }).length, 0);
@@ -2584,6 +2604,58 @@ describe('checkL18 id-filename-mismatch', () => {
     assert.equal(checkL18('sources/foo-bar.md', { id: 'TODO' }).length, 0);
     assert.equal(checkL18('sources/foo-bar.md', { id: '   ' }).length, 0);
     assert.equal(checkL18('sources/foo-bar.md', { id: 42 }).length, 0);
+  });
+});
+
+describe('runLint L03 fix: L18 is recomputed after a rename', () => {
+  test('a stale pre-rename L18 finding does not survive a rename that resolves it', async () => {
+    const tmp = await makeTmp();
+    try {
+      await makeWiki(tmp);
+      // `id` already matches what the NEW (post-rename) filename will
+      // derive, but not the current, badly-cased one — so L18 fires here
+      // against the pre-rename path, and the L03 rename in this same --fix
+      // run resolves the very mismatch it reported.
+      const fm = renderFm(validSourceFm({ id: 'foo-bar', title: 'Foo Bar' }));
+      await writeFile(join(tmp, 'wiki', 'sources', 'Foo_Bar.md'), fm + 'Body.');
+
+      const result = await runLint(tmp, { fix: true, dryRun: false });
+
+      const l03 = result.findings.find(f => f.id === 'L03-slug-style' && f.file === 'sources/Foo_Bar.md');
+      assert.ok(l03 && l03.fix_applied, 'expected the rename to have actually happened in this run');
+
+      const l18 = result.findings.filter(f => f.id === 'L18-id-filename-mismatch');
+      assert.equal(l18.length, 0,
+        `expected no L18 finding to survive a rename that already resolved it, got:\n${JSON.stringify(l18, null, 2)}`);
+
+      // An immediate second run must agree — it always did; the bug was
+      // only in what the FIRST run reported.
+      const result2 = await runLint(tmp, { fix: true, dryRun: false });
+      assert.equal(result2.findings.filter(f => f.id === 'L18-id-filename-mismatch').length, 0);
+    } finally {
+      await removeTmp(tmp);
+    }
+  });
+
+  test('a genuine mismatch surviving the rename is re-flagged against the new path, not the old one', async () => {
+    const tmp = await makeTmp();
+    try {
+      await makeWiki(tmp);
+      // `id` matches neither the old nor the new basename — a real,
+      // unrelated mismatch that the rename does not touch.
+      const fm = renderFm(validSourceFm({ id: 'totally-different-id', title: 'Foo Bar' }));
+      await writeFile(join(tmp, 'wiki', 'sources', 'Foo_Bar.md'), fm + 'Body.');
+
+      const result = await runLint(tmp, { fix: true, dryRun: false });
+
+      const l18 = result.findings.filter(f => f.id === 'L18-id-filename-mismatch');
+      assert.equal(l18.length, 1,
+        `expected exactly one surviving L18 finding, got:\n${JSON.stringify(l18, null, 2)}`);
+      assert.equal(l18[0].file, 'sources/foo-bar.md',
+        'the recomputed finding must point at the NEW (post-rename) path, not the stale pre-rename one');
+    } finally {
+      await removeTmp(tmp);
+    }
   });
 });
 

--- a/src/scripts/wiki.mjs
+++ b/src/scripts/wiki.mjs
@@ -35,6 +35,7 @@ import {
 import { sanitizeExternalIdsObject } from './external-ids.mjs';
 import { atomicWrite } from './lib/fsx.mjs';
 import { isExempt } from './lib/globs.mjs';
+import { slugify } from './lib/slug.mjs';
 import {
   edgeTypeByName,
   skipReverseFor,
@@ -62,28 +63,6 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 // ---------------------------------------------------------------------------
 // 3. Utils
 // ---------------------------------------------------------------------------
-
-/**
- * Convert a title string to a kebab-case slug.
- * Lowercase, hyphenate, strip punctuation, collapse whitespace.
- * Pure function, no I/O.
- * @param {string} title
- * @returns {string}
- */
-function slugify(title) {
-  return title
-    .toLowerCase()
-    // Replace accented chars with ascii equivalents where possible
-    .normalize('NFD')
-    .replace(/[̀-ͯ]/g, '')
-    // Replace non-alphanumeric (except spaces and hyphens) with space
-    .replace(/[^a-z0-9\s-]/g, ' ')
-    // Collapse any whitespace and hyphens to a single hyphen
-    .trim()
-    .replace(/[\s-]+/g, '-')
-    // Remove leading/trailing hyphens
-    .replace(/^-+|-+$/g, '');
-}
 
 /**
  * Parse YAML frontmatter from a markdown file string.

--- a/src/skills/core/check/SKILL.md
+++ b/src/skills/core/check/SKILL.md
@@ -100,7 +100,7 @@ node _lumina/scripts/lint.mjs --fix --json
 The `--fix` pass:
 - Applies the supported auto-fixes listed in `references/lint-checks.md`
   (L01, L02, L03, L05, L06, L07, L09)
-- Leaves every other check (L04, L08, L10, L11, L12, L13, L14, L16, L17)
+- Leaves every other check (L04, L08, L10, L11, L12, L13, L14, L16, L17, L18)
   for manual correction
 - Within a fixable check, some individual findings still can't be repaired
   safely (e.g. an L01 on a `number`/`enum` field with no safe default, or an

--- a/src/skills/core/check/references/lint-checks.md
+++ b/src/skills/core/check/references/lint-checks.md
@@ -9,7 +9,7 @@ output in `/lumi-check`.
 |----|------|----------|-------------|
 | L01 | Missing frontmatter field | error | Mostly — derives a type-valid value (`[]` for arrays, dates from a legacy field or file mtime, `id`/`type`/`title` from the file itself); leaves `number`/enum fields with no safe default standing |
 | L02 | Wrong frontmatter type | error | Mostly — wraps a bare string into an array, reconstructs `key_sources`/`related_concepts` from `graph/edges.jsonl` (falls back to `[]`); treats the literal value `TODO` as invalid on any declared field and recovers `id`/`type`/`title` from it the same way a missing field is recovered; cannot repair `number`/enum values or a `TODO` on any other string field |
-| L03 | Non-kebab slug | error | Yes — renames file and rewrites wikilinks |
+| L03 | Non-kebab slug | error | Yes — renames file, rewrites wikilinks, updates the page's own `id`; refused when the target name is taken |
 | L04 | Orphan page | warning | No — user decides whether to link or leave |
 | L05 | Broken wikilink | error | Only when unambiguous — rewrites the link when exactly one page's basename matches; ambiguous or zero matches are reported with candidates instead of guessed |
 | L06 | Missing reverse edge | error | Yes — writes the reverse edge |
@@ -23,6 +23,7 @@ output in `/lumi-check`.
 | L14 | `external_ids` value fails validation for its namespace | error | No — user must correct or remove the value |
 | L16 | `external_ids` value disagrees with the value derived from `urls[]` | warning | No — run `/lumi-migrate-legacy --backfill-ids` to reconcile |
 | L17 | Dangling edge endpoint (edge `from`/`to` does not resolve to an existing wiki file) | error | No — user must run `wiki.mjs remove-edge` or recreate the missing page |
+| L18 | Frontmatter `id` no longer names the file it lives in | warning | No — by design; user sets `id` to match the file or renames the file to match `id` |
 
 (L15 is intentionally unassigned — reserved for a future collision check.)
 
@@ -49,6 +50,7 @@ Advisories to surface to the user:
 - L12: `raw_paths` missing, unsafe, or transient
 - L13: `external_ids` missing a derivable namespace
 - L16: `external_ids` disagrees with `urls[]`
+- L18: `id` no longer names the file it lives in
 
 ## Fix Behavior
 
@@ -87,7 +89,14 @@ Advisories to surface to the user:
   `--fix` pass. A folder name that isn't one of the wiki's own entity types
   is never accepted this way, so an unrelated identifier that happens to
   contain a slash (for example an arXiv id) is never mistaken for a match.
-- L03 renames the file to kebab-case and rewrites matching wikilinks.
+- L03 renames the file to kebab-case, rewrites matching wikilinks, and
+  updates the page's own `id` (and legacy `slug`) so it still names the file.
+  The rename is refused, and the finding left standing with an explanation,
+  when the kebab-case name is already taken by another page, when two flagged
+  files would kebab-case to the same name, or when the name is made entirely
+  of punctuation and would leave nothing behind. Renaming over an existing
+  page would destroy it, so the collision is surfaced for a human instead:
+  merge the two pages, or rename one by hand, then re-run `--fix`.
 - L05 rewrites a broken wikilink only when exactly one page's basename
   matches (e.g. `[[agent-taxonomy]]` → `[[concepts/agent-taxonomy]]`).
   Ambiguous (multiple candidates) or zero-match links are never guessed — the
@@ -96,17 +105,16 @@ Advisories to surface to the user:
 - L07 deduplicates symmetric edges.
 - L09 regenerates the `<!-- lumina:index --> ... <!-- /lumina:index -->` block.
 
-L04, L08, L10, L11, L12, L13, L14, L16, and L17 require manual correction —
-none of them are touched by `--fix`. So do the individual L01/L02/L05
-findings above that `--fix` could recognize but not safely resolve on its
-own (a `number`/enum field with no default, or an ambiguous/unresolvable
-wikilink) — they remain in the findings list with `fixable: false` after a
-`--fix` pass. If L06 remains after `--fix`, the target page may not exist;
-identify it and suggest `/lumi-ingest` or `/lumi-edit`. For L13 and L16, the
-fix path is `/lumi-migrate-legacy --backfill-ids`, not `lint.mjs --fix`. For
-L17, the fix path is `wiki.mjs remove-edge` (drop the stale edge) or
-recreating the missing page the edge still points at — never hand-edit
-`edges.jsonl`.
+L04, L08, L10, L11, L12, L13, L14, L16, L17, and L18 require manual correction
+— none of them are touched by `--fix`. So do the individual L01/L02/L05
+findings above that `--fix` could recognize but not safely resolve on its own
+(a `number`/enum field with no default, or an ambiguous/unresolvable wikilink)
+— they remain in the findings list with `fixable: false` after a `--fix` pass.
+If L06 remains after `--fix`, the target page may not exist; identify it and
+suggest `/lumi-ingest` or `/lumi-edit`. For L13 and L16, the fix path is
+`/lumi-migrate-legacy --backfill-ids`, not `lint.mjs --fix`. For L17, the fix
+path is `wiki.mjs remove-edge` (drop the stale edge) or recreating the missing
+page the edge still points at — never hand-edit `edges.jsonl`.
 
 ### `--suggest` — resolutions for what `--fix` could not resolve
 

--- a/src/skills/core/check/references/lint-checks.md
+++ b/src/skills/core/check/references/lint-checks.md
@@ -23,7 +23,7 @@ output in `/lumi-check`.
 | L14 | `external_ids` value fails validation for its namespace | error | No — user must correct or remove the value |
 | L16 | `external_ids` value disagrees with the value derived from `urls[]` | warning | No — run `/lumi-migrate-legacy --backfill-ids` to reconcile |
 | L17 | Dangling edge endpoint (edge `from`/`to` does not resolve to an existing wiki file) | error | No — user must run `wiki.mjs remove-edge` or recreate the missing page |
-| L18 | Frontmatter `id` no longer names the file it lives in | warning | No — by design; user sets `id` to match the file or renames the file to match `id` |
+| L18 | Frontmatter `id` no longer names the file it lives in | warning | No — by design; user sets `id` to match the file or renames the file to match `id`. The pre-v0.1 form `<own-entity-dir>/<slug>` (e.g. `concepts/ab-testing` on a page in `concepts/`) is tolerated and never rewritten; a prefix naming a *different* entity dir is not |
 
 (L15 is intentionally unassigned — reserved for a future collision check.)
 

--- a/src/skills/core/ingest/references/step-02-lint.md
+++ b/src/skills/core/ingest/references/step-02-lint.md
@@ -38,10 +38,11 @@ wrapping a bare string into an array or rebuilding a `key_sources`/
 `related_concepts` list from the graph), L03 (kebab slugs), L05 (rewrites a
 broken wikilink only when exactly one page's basename matches), L06 (missing
 reverse edges), L07 (dedupe symmetric edges), and L09 (refresh index block).
-Everything else — plus any specific L01/L02/L05 finding `--fix` recognized
+Everything else — plus any specific L01/L02/L03/L05 finding `--fix` recognized
 but could not safely resolve on its own (typically a `number`/`enum` field
-with no safe default, or an ambiguous/unresolvable wikilink) — is left
-standing and reported only.
+with no safe default, an ambiguous/unresolvable wikilink, or a rename whose
+kebab-case name is already taken by another page) — is left standing and
+reported only.
 
 Now narrow the result to the pages *this ingest run* touched — the source
 page itself plus every page it links to (new or updated stubs) — so an
@@ -83,9 +84,10 @@ gate:
 **Case B — `errors_count > 0`:**
 - One or more findings on this entry's own pages survived `--fix` — typically
   a `number`/`enum` frontmatter field with no safe default (L01/L02), an
-  ambiguous wikilink `--fix` would not guess at (L05), a missing edge
-  confidence (L08), a foundation alias conflict (L10), or a dangling edge
-  (L17).
+  ambiguous wikilink `--fix` would not guess at (L05), a slug rename `--fix`
+  refused because the kebab-case name already belongs to another page (L03),
+  a missing edge confidence (L08), a foundation alias conflict (L10), or a
+  dangling edge (L17).
 - Do **not** write `ingest_status: linted`. This is the gate the incident
   above is about — an entry with a standing error on its own pages must never
   be marked clean.


### PR DESCRIPTION
`lint --fix` runs wiki-wide on **every** `/lumi-ingest` and `/lumi-edit` (`step-02-lint.md`), so everything below sat on the default path.

## Reproduced before, re-checked after

| | before | after |
|---|---|---|
| `foo-bar.md` + `Foo_Bar.md` in one dir | one file left, body gone, exit 0, `fix_applied: true` | both intact, finding stands with an explanation |
| two names kebab-casing to one slug | exit 3, **0 bytes** of JSON, wiki half-repaired, later findings skipped | run completes, JSON intact, unrelated files still fixed |
| `Nhà-Nguyễn.md` | `nh-nguyn.md` | `nha-nguyen.md`, links and `id` follow |

`rename()` was called with nothing checked at its destination, and the file list was captured before any rename — so the second finding read a path the first had already moved, threw ENOENT, and took the whole run down with it.

## Also fixed

- `___.md` kebab-cased to the empty string and was renamed to `.md` — the page left the wiki.
- The page's own `id` was never updated after a rename, and L03 stops firing once the basename is kebab-case, so the mismatch was permanent and invisible.
- One unwritable file let its rename error escape and cost the caller the entire report.
- L09 rendered the index from a pre-rename file list, listing pages under names they no longer had.

## slugify moved to `lib/slug.mjs`

The fixer carried a second, hand-written kebab transform that skipped NFD entirely. One definition now backs both `wiki.mjs slug` and the L03 rename. **Output is unchanged** — verified identical over 20k fuzzed inputs — so `wiki.mjs slug` behaves exactly as before. `Đ`, `ø`, `ß`, `ł` are still dropped rather than transliterated; that is deliberate and left for a separate change, since altering it changes the slug for titles a wiki may already have pages under.

## New check L18

Reports an `id` that no longer names its file. Warning, never auto-repaired (an author's deliberate id would be destroyed), and the only way to find a wiki the old fixer already damaged — the damage is otherwise unrecoverable except through git.

Honours all three legitimate id shapes plus the legacy `<entity-dir>/<slug>` form (a real 813-page wiki had 179 of those). Tested against every shape: **1 true positive, 0 false positives**. Being a warning, it never blocks the ingest gate, which filters on `severity === 'error'`.

## Behaviour change worth knowing

A refused L03 is now an unresolved error. If it lands on a page the current ingest touched, ingest halts and asks instead of proceeding — which previously it did by destroying a page.

## Verification

- 482 script tests (was 468), 285 installer, doc-counts 3, `ci:idempotency` 5/5, `ci:package`, `ci:cold-start` 246 ms, `ci:agent-isolation`.
- Each guard mutation-tested individually: reverting it fails exactly its own tests and no others.
- Installed into a real sandbox: `lib/` copied, both scripts import it, rename produces `nha-nguyen.md` with a correct `id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)