### PR TITLE
ci: bump action pins off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -87,7 +87,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary

CI has been emitting this warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4.

This is about the **runtime GitHub uses to execute JavaScript actions**, not the Node version our tests run on. This PR bumps the affected action pins so nothing targets the deprecated `node20` Actions runtime.

## Version changes

| Action | File(s) | Old | New |
|---|---|---|---|
| `actions/checkout` | `ci.yml` (x2), `claude.yml` | `v4` | `v7` |
| `actions/setup-node` | `ci.yml` | `v4` | `v7` |
| `actions/setup-python` | `ci.yml` | `v5` | `v7` |

Bare major-version pins, matching the style already used in `publish.yml` (`actions/checkout@v6`, `actions/setup-node@v6`).

## Left unchanged (and why)

- **`oven-sh/setup-bun@v2`** (`ci.yml`) — already resolves to the `node24` runtime. Confirmed by reading `action.yml`'s `runs.using` for the `v2` tag: it's `node24`, same as the latest `v2.2.0` release. No bump needed.
- **`anthropics/claude-code-action@v1`** (`claude.yml`) — this is a `composite` action, not a JS action, so it has no runtime of its own to deprecate. Its only nested action call is `oven-sh/setup-bun`, pinned to a commit SHA for the `v2.2.0` release, which is already `node24`. No bump needed.
- **`publish.yml`** — already modernized (`actions/checkout@v6`, `actions/setup-node@v6`, Node 24). Left untouched; it does not warn.
- **`ci.yml`'s `node-version: [20]` test matrix** — explicitly out of scope. This is the Node.js runtime our *tests* run under, not the Actions JS runtime. History (`167ee7e`, `90ff959`) shows Node 22 was deliberately dropped from the matrix due to an upstream `node:test` structured-clone IPC bug that hit every OS; changing the tested runtime is a separate decision.

## Breaking-change check

Read release notes / `action.yml` diffs for each bump before picking `v7`:

- **`actions/checkout` v4 -> v7**: v7 adds an `allow-unsafe-pr-checkout` gate that blocks checking out fork PRs under `pull_request_target`/`workflow_run` unless explicitly allowed. Neither `ci.yml` (`push`/`pull_request`) nor `claude.yml` (`issue_comment`/`pull_request_review_comment`/`pull_request_review`) use those triggers, so this doesn't affect us. Other defaults (`persist-credentials`, `fetch-depth`, etc.) are unchanged.
- **`actions/setup-node` v4 -> v7**: v5 introduced automatic package-manager caching driven by a `packageManager` field in `package.json`; this repo's `package.json` has no such field, so it's inert. `node-version` and `cache: npm` inputs are unchanged and still valid in v7.
- **`actions/setup-python` v5 -> v7**: `python-version` input is unchanged. v7 only removed an already-unused `pip-install` input. No impact on our usage (`python-version: "3.11"`).

No breaking change required a workflow rewrite, so none was done.

## Known drift (not fixed here, flagged as follow-up)

`docs/DEVELOPMENT.md:108` claims "CI runs all three across Node {20, 22}" while the actual matrix is `[20]` only (Node 22 was removed for the `node:test` IPC bug mentioned above). That's pre-existing documentation drift, unrelated to this PR's scope, and should be corrected separately.

## Test plan

- [x] YAML syntax validated for both edited workflow files.
- [x] Confirmed via each action's `action.yml` that the new pins resolve to `node24` (`runs.using`).
- [ ] CI run on this PR should complete without the Node 20 deprecation warning.
