### PR TITLE
ci: move the test matrix to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        # Node 22 node:test runner has a structured-clone IPC bug
-        # (ERR_TEST_FAILURE / "Unable to deserialize cloned data due to invalid
-        # or unsupported version" in node:internal/test_runner/runner) that
-        # surfaces intermittently on every hosted runner (Windows, macOS, and
-        # ubuntu). Stay on Node 20 across all OSes until the upstream fix
-        # lands; revisit when Node 22.x patches the runner IPC.
-        node-version: [20]
+        # Node 20 reached end-of-life in April 2026, and actions targeting its
+        # runtime are deprecated on hosted runners, so the test matrix moved to
+        # 24. Node 22 was skipped rather than passed through: it carried a
+        # structured-clone IPC bug in the node:test runner (ERR_TEST_FAILURE /
+        # "Unable to deserialize cloned data due to invalid or unsupported
+        # version") that surfaced intermittently on every hosted OS and was why
+        # this matrix sat on a single version at all. Both suites were run on
+        # 24 locally before the switch with no sign of it.
+        #
+        # Deliberate gap: package.json still declares `engines: >=20.0.0`, so
+        # Node 20 and 22 remain supported but are no longer exercised here. An
+        # API available only in newer Node would break those users without
+        # failing CI. Narrow `engines` if that trade stops being worth it.
+        node-version: [24]
 
     steps:
       - name: Checkout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,7 +211,7 @@ explicitly so a follow-up can translate before release.
 
 Every PR runs:
 
-- **Node 20 / Node 22 × ubuntu / macOS / windows** (6 matrix cells)
+- **Node 24 × ubuntu / macOS / windows** (3 matrix cells)
 - **Bun smoke** (ubuntu) — Bun is not a supported runtime but divergences are
   caught early
 - **`npm run test:all`** — installer, scripts, Python

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -105,7 +105,7 @@ npm run ci:idempotency     # install twice → git diff must be empty
 npm run ci:package         # npm pack --dry-run, validate files allowlist + postinstall ban
 ```
 
-CI runs all three across Node {20, 22} × {ubuntu, macos, windows}. Failure on any cell blocks merge.
+CI runs all three on Node 24 × {ubuntu, macos, windows}. Failure on any cell blocks merge. `engines` still allows Node >= 20, which CI no longer exercises.
 
 ### What each gate catches
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -79,7 +79,7 @@ lumina-wiki/
 │   ├── planning-artifacts/       # Architecture decisions, specs
 │   ├── implementation-artifacts/ # Deferred work, implementation notes
 │   └── user-guide/               # End-user guides (EN, VI, ZH)
-├── .github/workflows/            # CI matrix (Node 20/22 × 3 platforms)
+├── .github/workflows/            # CI matrix (Node 24 × 3 platforms)
 ├── package.json                  # ESM, no devDependencies, 5 deps
 ├── package-lock.json
 ├── CLAUDE.md                     # Agent rules (read first)

--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -44,7 +44,7 @@ A separate global "hub" mode (`lumina wikis` CLI + `lumi-hub` skill, `src/instal
 
 **Test runners:** `node --test` (built-in `node:test` + `node:assert/strict`) for JS/MJS; `pytest -q` for Python. **No Jest, no Vitest, no devDependencies.**
 
-**CI:** Node 20 × Node 22 × {Ubuntu, macOS, Windows} = 6 runners, `fail-fast: false`. Trigger: push to main + all PRs.
+**CI:** Node 24 × {Ubuntu, macOS, Windows} = 3 runners, `fail-fast: false`. Trigger: push to main + all PRs. `engines` still allows Node >= 20; CI no longer exercises it.
 
 ---
 


### PR DESCRIPTION
Follows #52, which bumped the action pins off the deprecated Node 20 runtime. This is the other half: the matrix itself.

## What changed

```diff
-        node-version: [20]
+        node-version: [24]
```

Node 20 reached end-of-life in April 2026, so CI was testing on a runtime that no longer receives security patches.

**Node 22 is skipped, not passed through.** It carried a structured-clone IPC bug in the `node:test` runner (`ERR_TEST_FAILURE` / "Unable to deserialize cloned data due to invalid or unsupported version") that surfaced intermittently on every hosted OS, and is why this matrix sat on a single version at all (167ee7e). Rather than assume Node 24 is unaffected, both suites were run on it locally before making the change:

```
npx node@24 --test src/scripts/*.test.mjs     530 pass, 0 fail
npx node@24 --test src/installer/*.test.js    356 pass, 0 fail
```

No sign of the bug.

## What deliberately did not change

`engines` stays at `>=20.0.0`. Narrowing it to `>=24` would make npm refuse installs on Node 20 and 22 for everyone already on this package — a breaking change that needs a major version and a changelog entry, not a CI commit.

The trade is real and is recorded in the workflow comment: Node 20 and 22 remain supported and are no longer exercised, so an API available only in newer Node would break those users without failing CI. Filed separately for a later decision.

## Docs

Three live docs described a six-cell Node 20/22 matrix. That was already wrong before this PR — the matrix has been a single version since 167ee7e — so `CONTRIBUTING.md`, `docs/project-context.md`, and `docs/codebase-summary.md` are corrected to match reality, along with `docs/DEVELOPMENT.md`.

Planning artifacts under `docs/planning-artifacts/` still say Node 20/22; those are locked historical records and are left alone.