### PR TITLE
docs: correct every live CI reference left stale by the Node 24 move

### DIFF
--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -444,21 +444,30 @@ Body opens with: "Read `README.md` at the project root before this SKILL.md." th
 
 ## 7. CI & packaging
 
-**Matrix:** Node {20, 22} × {ubuntu, macos, windows} = 6 cells, `fail-fast: false`. Every cell runs all 8 steps; any failure blocks merge.
+**Matrix:** two jobs. `installability` (`Node ${{ matrix.node-version }} / ${{ matrix.os }}`) — Node 24 × {ubuntu, macos, windows} = 3 cells, `fail-fast: false`; any failure blocks merge. Not every cell runs every step — `ci:cold-start` is gated `if: runner.os == 'Linux'`. `bun-smoke` (`Bun smoke (ubuntu)`, ubuntu only) — `continue-on-error: true`, advisory, does not block merge.
 
-Steps (in order):
-1. `npm ci`
-2. `pip install pytest`
-3. `npm run test:installer` — `node --test src/installer/*.test.js`
-4. `npm run test:scripts` — `node --test src/scripts/*.test.mjs`
-5. `npm run test:python` — `pytest src/tools/tests -q`
-6. `node bin/lumina.js --version --no-update` — CLI smoke
-7. `npm run ci:idempotency`
-8. `npm run ci:package`
+Steps (`installability`, in order):
+1. Checkout — `actions/checkout@v7`
+2. Setup Node — `actions/setup-node@v7`, `cache: npm`
+3. Setup Python — `actions/setup-python@v7`, `python-version: "3.11"`
+4. `npm ci`
+5. `python -m pip install -r src/tools/requirements.txt`
+6. `npm run test:installer` — three chained stages: `test:installer:commands`, `test:installer:commands-agents`, then `node --test` over `bin/*.test.js` plus 11 named `src/installer/*.test.js` files
+7. `npm run test:scripts` — `node --test` over 11 named `src/scripts/*.test.mjs` files
+8. `npm run test:python` — `pytest src/tools/tests -q`
+9. `npm run test:catalog` — catalog + doc-count integrity
+10. `node bin/lumina.js --version --no-update` — CLI smoke
+11. `npm run ci:idempotency`
+12. `npm run ci:cold-start` — **Linux-only** (`if: runner.os == 'Linux'`)
+13. `npm run ci:package`
+14. `npm run ci:agent-isolation`
+15. `npm run test:e2e` — end-to-end (librarian mode)
+
+`bun-smoke` steps: checkout, `oven-sh/setup-bun@v2` (bun-version latest), `bun install`, `bun bin/lumina.js --version --no-update`, `bun run dev:sandbox -- --yes --packs core`.
 
 **Idempotency invariant (`scripts/ci-idempotency.mjs`):**
 
-Two scenarios: `core-default` and `full-pack` (core + research + reading × 6 IDE targets). For each:
+Five scenarios: `core-default`; `full-pack` (core + research + reading + learning × 6 IDE targets); `multilingual-en`, `multilingual-vi`, `multilingual-zh` (each `--lang <x> --packs core,research`). For each:
 1. `git init`, install once, commit baseline
 2. Install again with same args
 3. `git diff --exit-code` over: `README.md`, `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `QWEN.md`, `IFLOW.md`, `.cursor`, `.claude`, `.agents`, `_lumina/config`, `_lumina/schema`, `_lumina/scripts`, `_lumina/tools`, `.env.example`, `wiki`, `raw`
@@ -539,7 +548,7 @@ npm run ci:idempotency     # install twice → git diff over watched paths must 
 npm run ci:package         # npm pack --dry-run, validate files allowlist + postinstall ban
 ```
 
-These three commands are exactly what CI runs across Node {20, 22} × {ubuntu, macos, windows}. If they pass locally, CI will pass.
+These three commands are a subset of what CI runs across Node 24 × {ubuntu, macos, windows} (`installability` job) — see §7 for the full 15-step list, which also includes `test:catalog`, `ci:cold-start` (Linux-only), `ci:agent-isolation`, and `test:e2e`. Passing locally covers the core gates, not all of CI.
 
 ### Per-module quick tests
 

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -105,7 +105,7 @@ Two layers:
 | Install time | < 60 s | ✓ |
 | Cold-start CLI | < 300 ms | ✓ |
 | Idempotent reinstall | `git diff` empty | ✓ |
-| Cross-platform (Node 20/22 × macOS/Linux/Windows) | 6-cell CI green | ✓ |
+| Cross-platform (Node 24 × macOS/Linux/Windows) | 3-cell CI green | ✓ |
 | Zero-tolerance path safety | No `..` / absolute traversal | ✓ |
 | User adoption | Open-source usage, GitHub stars | Growing |
 | Skill extensibility | 3+ custom-authored packs possible | ✓ (research/reading packs ship; more TBD) |

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -27,7 +27,7 @@ Focus: Stability, local capabilities, and v1.x feature expansion.
 | **Local text-document ingestion** (.docx, .rtf, .epub) | Planned | — |
 | **Vision/OCR ingestion** (.png, .jpg, scanned PDF) | Design pending | — |
 | **Paper ranking & influence** (citation counts, altmetrics) | Planned | [spec-paper-ranking.md](./planning-artifacts/specs/spec-paper-ranking.md) |
-| **CI/CD hardening** (Bun, Node 22 LTS) | Planned | — |
+| **CI/CD hardening** (advisory Bun smoke job; Node 24 matrix) | Shipped v1.x | — |
 | **Stability lock** (CLI contract published; --cwd deprecation; exit-4 cancellation) | Shipped v1.x | — |
 | **Schema parity** (cross-source ID handling) | In progress | — |
 
@@ -76,7 +76,7 @@ All locked:
 - ✅ **Install time:** < 60 s (baseline)
 - ✅ **Cold-start CLI:** < 300 ms (baseline)
 - ✅ **Idempotent reinstall:** `git diff` empty over watched paths
-- ✅ **Cross-platform:** Node 20/22 × {macOS, Linux, Windows}
+- ✅ **Cross-platform:** Node 24 × {macOS, Linux, Windows}
 - ✅ **Zero path safety issues:** `safePath()` enforced everywhere
 - ✅ **Skills installed correctly:** Symlink ladder works; fallback to copy on Windows
 - ✅ **Zero telemetry:** Only optional npm registry version check (2s timeout)


### PR DESCRIPTION
Follow-up to #56, from a Codex review comment on that PR.

## What Codex caught

#56 updated `docs/project-context.md` §2 to the Node 24 matrix but left §7 (line 447) and §10 (line 542) describing six cells of Node 20/22. The file contradicted itself, and the later sections are the ones contributors actually read for testing guidance.

## What it missed

Three more live references, in files Codex did not look at:

- `docs/project-overview-pdr.md:108` — success-metric row `Node 20/22 × ... | 6-cell CI green`
- `docs/project-roadmap.md:30` — `CI/CD hardening (Bun, Node 22 LTS) | Planned`
- `docs/project-roadmap.md:79` — `Cross-platform: Node 20/22 × {macOS, Linux, Windows}`

## What reading §7 against ci.yml turned up

The matrix was the smaller half of the problem:

| §7 claimed | `ci.yml` actually does |
|---|---|
| 6 cells, Node 20/22 | 3 cells, Node 24 |
| "every cell runs all 8 steps" | 15 steps, and `ci:cold-start` is gated `if: runner.os == 'Linux'` |
| step 2 `pip install pytest` | `pip install -r src/tools/requirements.txt`, Python pinned to 3.11 |
| — | `test:catalog`, `ci:agent-isolation`, `test:e2e` all missing from the list |
| — | second job `bun-smoke` missing entirely (`continue-on-error: true`, advisory) |
| `test:installer` = `node --test src/installer/*.test.js` | not a glob — three chained stages over explicit file lists |
| `test:scripts` = `node --test src/scripts/*.test.mjs` | not a glob — 11 named files |
| idempotency: "Two scenarios" | five (`core-default`, `full-pack`, `multilingual-{en,vi,zh}`), and `full-pack` includes `learning` |

The `test:installer` glob claim is the one with teeth: because it is three chained stages, reading only the last summary block undercounts the suite (285 of 377). The doc now says so.

The step list is verified one-for-one against `ci.yml`, in order.

## Deliberately not changed

- **`engines.node` stays `>=20.0.0`.** npm treats a failing `engines` range as an install *error*, not a warning, so narrowing it would lock out existing users. The resulting gap — declared `>=20`, exercised only on 24 — is tracked in #57.
- **`docs/planning-artifacts/**`** — locked historical records, meant to describe the matrix as it stood when written.
- The Node 22 rationale (the `node:test` structured-clone IPC bug) stays in the `ci.yml` comment. A roadmap table cell is the wrong place for it.

Docs only — no source, workflow, or `package.json` changes.