### PR TITLE
docs: record why 1.11.0 and 1.12.0 never shipped, and how not to repeat it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1232,7 +1232,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 [Unreleased]: https://github.com/tronghieu/lumina-wiki/compare/v1.13.0-next.0...HEAD
 [1.13.0-next.0]: https://github.com/tronghieu/lumina-wiki/compare/v1.10.1...v1.13.0-next.0
-[1.12.0]: https://github.com/tronghieu/lumina-wiki/compare/v1.10.1...v1.12.0
+[1.12.0]: https://github.com/tronghieu/lumina-wiki/compare/v1.10.1...archive/1.12.0
 [1.5.0]: https://github.com/tronghieu/lumina-wiki/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/tronghieu/lumina-wiki/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/tronghieu/lumina-wiki/compare/v1.2.0...v1.3.0

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -138,19 +138,47 @@ The npm dist-tag is derived from the version itself — the workflow never takes
 
 | `package.json` version | git tag | npm dist-tag | GitHub Release |
 |---|---|---|---|
-| `1.12.0` | `v1.12.0` | `latest` | normal |
-| `1.12.0-next.0` | `v1.12.0-next.0` | `next` | pre-release |
-| `1.12.0-rc.1` | `v1.12.0-rc.1` | `rc` | pre-release |
+| `1.14.0` | `v1.14.0` | `latest` | normal |
+| `1.14.0-next.0` | `v1.14.0-next.0` | `next` | pre-release |
+| `1.14.0-rc.1` | `v1.14.0-rc.1` | `rc` | pre-release |
 
-A version with a pre-release identifier publishes to a channel of that name and **leaves `latest` untouched**, so nobody running `npx lumina-wiki install` is affected. Build metadata is not part of the channel (`1.12.0+build-next` is a stable release, not a `next` one). An identifier the workflow cannot read as a channel — empty, uppercase, purely numeric, literally `latest`, or one npm itself refuses because it parses as a version range (`x`, `v1`) — fails the job rather than guessing.
+A version with a pre-release identifier publishes to a channel of that name and **leaves `latest` untouched**, so nobody running `npx lumina-wiki install` is affected. Build metadata is not part of the channel (`1.14.0+build-next` is a stable release, not a `next` one). An identifier the workflow cannot read as a channel — empty, uppercase, purely numeric, literally `latest`, or one npm itself refuses because it parses as a version range (`x`, `v1`) — fails the job rather than guessing.
+
+### A bump is not a release
+
+Merging a `chore(release):` commit does nothing on its own. The tag is what
+publishes — `publish.yml` triggers on `push: tags: v*` and on nothing else. A
+bumped `package.json` and a written `CHANGELOG.md` entry sitting on `main`
+with no tag behind them read exactly like a shipped release and are not one.
+
+This has already happened twice. **1.11.0** (2026-07-27) and **1.12.0**
+(2026-08-12) were each bumped, documented and merged, and neither was ever
+tagged, so neither reached npm: `latest` sat on 1.10.1 for over a month while
+the repo read as though two releases had shipped. Their content first reached
+users in `1.13.0-next.0`. Both commits now carry an annotated
+`archive/<version>` tag recording what happened; those deliberately sit
+outside the `v*` namespace so they never trigger a publish.
+
+Finish every release by confirming the channel actually moved:
+
+```bash
+npm view lumina-wiki dist-tags
+git tag --list 'v*' --sort=-v:refname | head -3
+```
+
+If the version you just bumped is absent from both, nothing shipped. Do not
+re-tag an old release commit to catch up: `publish.yml` reads the version from
+that commit's `package.json`, so the job would pass its own check and push a
+months-old build — bugs included — straight to `latest`. Roll the missed
+content into the next version instead, which is what 1.13.0-next.0 did.
 
 ### Cutting a pre-release
 
 ```bash
-# 1.12.0-next.0, .next.1, … as many as the change needs
-npm version 1.12.0-next.0 --no-git-tag-version
-git commit -am "chore(release): 1.12.0-next.0"
-git tag v1.12.0-next.0
+# 1.14.0-next.0, .next.1, … as many as the change needs
+npm version 1.14.0-next.0 --no-git-tag-version
+git commit -am "chore(release): 1.14.0-next.0"
+git tag v1.14.0-next.0
 git push origin main --tags
 ```
 
@@ -160,11 +188,11 @@ Testers then run:
 npx lumina-wiki@next install
 ```
 
-When the change is ready, bump to the plain `1.12.0`, tag it, and the same workflow moves `latest`.
+When the change is ready, bump to the plain `1.14.0`, tag it, and the same workflow moves `latest`.
 
 ### What pre-release users see
 
-`checkForUpdate()` always queries the `latest` dist-tag, and `isNewerVersion()` follows semver precedence — a stable release outranks the pre-release that led to it. So someone on `1.12.0-next.0` is nudged to upgrade the moment `1.12.0` ships, but is not nagged while only pre-releases exist. They are *not* notified about a newer build within the same channel; re-running `npx lumina-wiki@next install` is the way to pick that up.
+`checkForUpdate()` always queries the `latest` dist-tag, and `isNewerVersion()` follows semver precedence — a stable release outranks the pre-release that led to it. So someone on `1.14.0-next.0` is nudged to upgrade the moment `1.14.0` ships, but is not nagged while only pre-releases exist. They are *not* notified about a newer build within the same channel; re-running `npx lumina-wiki@next install` is the way to pick that up.
 
 ### Before tagging anything
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -159,18 +159,26 @@ users in `1.13.0-next.0`. Both commits now carry an annotated
 `archive/<version>` tag recording what happened; those deliberately sit
 outside the `v*` namespace so they never trigger a publish.
 
-Finish every release by confirming the channel actually moved:
+Finish every release by confirming the channel actually moved. Both checks
+have to query a remote — a tag that exists only on your laptop is the exact
+failure being guarded against, and `git tag --list` would report it as
+present:
 
 ```bash
 npm view lumina-wiki dist-tags
-git tag --list 'v*' --sort=-v:refname | head -3
+git ls-remote --tags origin 'v*' | grep -v '\^{}'
 ```
 
-If the version you just bumped is absent from both, nothing shipped. Do not
-re-tag an old release commit to catch up: `publish.yml` reads the version from
-that commit's `package.json`, so the job would pass its own check and push a
-months-old build — bugs included — straight to `latest`. Roll the missed
-content into the next version instead, which is what 1.13.0-next.0 did.
+The version you just bumped has to appear in **both**. Missing from
+`ls-remote` means the tag never reached GitHub, so `publish.yml` never ran.
+Present there but missing from `dist-tags` means the workflow ran and failed
+— read its log rather than re-tagging.
+
+Do not re-tag an old release commit to catch up: `publish.yml` reads the
+version from that commit's `package.json`, so the job would pass its own
+check and push a months-old build — bugs included — straight to `latest`.
+Roll the missed content into the next version instead, which is what
+1.13.0-next.0 did.
 
 ### Cutting a pre-release
 


### PR DESCRIPTION
Follow-up to #59. The `next` build is published; this closes the hole that stranded two releases.

## The failure mode

`publish.yml` triggers on `push: tags: v*` and nothing else. Merging a `chore(release):` commit publishes nothing — but a bumped `package.json` sitting next to a written `CHANGELOG.md` entry on `main` reads exactly like a shipped release.

That gap swallowed **1.11.0** and **1.12.0**. Both were bumped, documented and merged; neither was ever tagged; `latest` sat on 1.10.1 for over a month while the repo read as though two releases had gone out. Confirmed independently: the publish workflow's run history goes straight from `bump version to 1.10.1` to `1.13.0-next.0`.

## Why the obvious repair is a trap

`git tag v1.12.0 63cc65f` looks like it just backfills history. It does not — the workflow reads the version out of *the commit being tagged*, so `test "$GITHUB_REF_NAME" = "v${version}"` **passes**, `1.12.0` carries no pre-release identifier so the channel resolves to `latest`, and a months-old build gets published to every user — including the data-loss bugs fixed in #43 (`lint --fix` overwrote pages) and #44 (`add-edge` corrupted the graph unrecoverably).

The section says this explicitly so the next person does not find out the expensive way.

## What is here

- **`docs/DEVELOPMENT.md` section 6** — new "A bump is not a release" subsection: the mechanic, what it cost, the two-command check that closes the loop, and why not to re-tag.
- **Illustrative version moved off `1.12.0`** throughout section 6. It had become a counter-example two paragraphs below the table using it as the happy path.
- **`CHANGELOG.md`** — the `[1.12.0]` compare link 404'd against a tag that was never created. Repointed at the new `archive/1.12.0` marker.

## Tags added outside this PR

Two annotated markers, pushed already since they carry no risk:

- `archive/1.11.0` at `8bb681b`
- `archive/1.12.0` at `63cc65f`

Each records that the version was bumped and documented but never released. They sit **outside the `v*` namespace on purpose** so they cannot trigger a publish — verified after pushing: no workflow run fired, and `dist-tags` still reads `latest: 1.10.1`, `next: 1.13.0-next.0`.

## Verified

| Check | Result |
|---|---|
| `ci:package`, `ci:idempotency` | pass |
| Every `compare/` link in `CHANGELOG.md` resolved against the GitHub API | no broken links |
| `compare/v1.10.1...archive/1.12.0` | resolves, ahead by 3 |
| Emoji in changed files | none |
