### PR TITLE
feat(scripts): assert a release actually shipped instead of trusting the bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,11 +110,29 @@ jobs:
             gh release create "${GITHUB_REF_NAME}" "${flags[@]}" --generate-notes
           fi
 
-      - name: Verify the release is live
-        # publish.yml is the only thing that publishes, so this is the last
-        # point at which the loop can be closed without relying on someone
-        # remembering to check. It re-derives the channel from the version and
-        # asserts the tag reached origin, the version reached npm, and the
-        # dist-tag actually moved. Retries because a freshly published
-        # dist-tag can take a moment to become visible on the registry.
+  verify:
+    name: Verify the release is live
+    needs: publish
+    runs-on: ubuntu-latest
+
+    # Deliberately a separate job from `publish`, not a final step inside it.
+    # `npm publish` is one-shot: a published version is immutable, so a rerun
+    # of the publish job fails at that step and never reaches verification.
+    # Isolated here, a transient registry hiccup can be rerun on its own --
+    # this job only reads.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Verify
+        # Re-derives the channel from package.json and asserts the tag reached
+        # origin, the version reached npm, and the dist-tag actually moved.
+        # Retries because a freshly published dist-tag can take a moment to
+        # become visible on the registry.
         run: node scripts/release-verify.mjs --retries 6 --delay 5000

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,3 +109,12 @@ jobs:
             echo "No CHANGELOG entry for ${version}; falling back to generated notes."
             gh release create "${GITHUB_REF_NAME}" "${flags[@]}" --generate-notes
           fi
+
+      - name: Verify the release is live
+        # publish.yml is the only thing that publishes, so this is the last
+        # point at which the loop can be closed without relying on someone
+        # remembering to check. It re-derives the channel from the version and
+        # asserts the tag reached origin, the version reached npm, and the
+        # dist-tag actually moved. Retries because a freshly published
+        # dist-tag can take a moment to become visible on the registry.
+        run: node scripts/release-verify.mjs --retries 6 --delay 5000

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -159,20 +159,34 @@ users in `1.13.0-next.0`. Both commits now carry an annotated
 `archive/<version>` tag recording what happened; those deliberately sit
 outside the `v*` namespace so they never trigger a publish.
 
-Finish every release by confirming the channel actually moved. Both checks
-have to query a remote — a tag that exists only on your laptop is the exact
-failure being guarded against, and `git tag --list` would report it as
-present:
+Finish every release by confirming the channel actually moved:
+
+```bash
+npm run release:verify
+```
+
+It reads the version out of `package.json`, re-derives the dist-tag that
+version publishes to, and asserts three things: the `v<version>` tag reached
+`origin`, npm holds that version, and the dist-tag actually points at it. Exit
+0 means released; exit 1 prints which check failed and what to do about it.
+
+Every check queries a remote on purpose — a tag that exists only on your
+laptop is the exact failure being guarded against, and `git tag --list` would
+report it as present. By hand, the same two questions are:
 
 ```bash
 npm view lumina-wiki dist-tags
 git ls-remote --tags origin 'v*' | grep -v '\^{}'
 ```
 
-The version you just bumped has to appear in **both**. Missing from
-`ls-remote` means the tag never reached GitHub, so `publish.yml` never ran.
-Present there but missing from `dist-tags` means the workflow ran and failed
-— read its log rather than re-tagging.
+Missing from `ls-remote` means the tag never reached GitHub, so `publish.yml`
+never ran. Present there but missing from `dist-tags` means the workflow ran
+and failed — read its log rather than re-tagging.
+
+You should rarely need to run this by hand: `publish.yml` runs
+`release:verify` as its own last step, so a publish that does not take effect
+turns the workflow red instead of passing quietly, which is how 1.11.0 and
+1.12.0 went unnoticed.
 
 Do not re-tag an old release commit to catch up: `publish.yml` reads the
 version from that commit's `package.json`, so the job would pass its own

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "test:python": "node scripts/run-pytest.mjs",
     "test:e2e": "node src/installer/librarian-e2e.test.mjs",
     "test:all": "npm run test:installer && npm run test:scripts && npm run test:python && npm run test:e2e && npm run test:catalog",
-    "test:catalog": "node --test scripts/verify-lumi-help.test.mjs scripts/verify-doc-counts.test.mjs",
+    "test:catalog": "node --test scripts/verify-lumi-help.test.mjs scripts/verify-doc-counts.test.mjs scripts/release-verify.test.mjs",
     "test:fs": "node --test src/installer/fs.test.js",
     "test:manifest": "node --test src/installer/manifest.test.js",
     "test:template": "node --test src/installer/template-engine.test.js",
@@ -111,6 +111,7 @@
     "ci:cold-start": "node scripts/measure-cold-start.mjs",
     "ci:package": "node scripts/ci-package.mjs",
     "ci:agent-isolation": "node scripts/ci-agent-host-isolation.mjs",
+    "release:verify": "node scripts/release-verify.mjs",
     "pack:check": "npm run ci:package",
     "dev:install": "node bin/lumina.js install",
     "dev:sandbox": "node scripts/dev-sandbox.mjs"

--- a/scripts/release-verify.mjs
+++ b/scripts/release-verify.mjs
@@ -11,7 +11,8 @@
  *
  * Every check queries a remote on purpose. A tag that exists only on the
  * machine running this script is the precise failure being guarded against,
- * and `git tag --list` would report it as present.
+ * and `git tag --list` would report it as present. For the same reason the
+ * registry is pinned rather than inherited from local npm config.
  *
  * Usage:
  *   node scripts/release-verify.mjs [--retries N] [--delay MS]
@@ -147,6 +148,18 @@ function remoteTagExists(version) {
   return { found: result.stdout.includes(ref) };
 }
 
+/**
+ * The registry publish.yml publishes to, pinned rather than inherited.
+ *
+ * `npm view` otherwise honours whatever `registry` is configured in ~/.npmrc or
+ * NPM_CONFIG_REGISTRY, which need not be where the release went. A stale mirror
+ * would fail a live release; worse, a private registry that happens to hold the
+ * same version and dist-tag would report a *failed* public publish as a
+ * success -- the exact false clean bill of health this script exists to
+ * prevent. Kept in step with `registry-url` in publish.yml.
+ */
+export const REGISTRY = 'https://registry.npmjs.org';
+
 /** What does the registry hold for this package? */
 function npmView(pkg, field) {
   // npm retries fetches twice by default with a five-minute timeout each. That
@@ -158,6 +171,7 @@ function npmView(pkg, field) {
     pkg,
     field,
     '--json',
+    `--registry=${REGISTRY}`,
     '--fetch-retries=0',
     '--fetch-timeout=15000',
   ]);

--- a/scripts/release-verify.mjs
+++ b/scripts/release-verify.mjs
@@ -79,15 +79,34 @@ export function deriveChannel(version) {
 
 const isWindows = process.platform === 'win32';
 
-function run(command, args) {
-  const result = spawnSync(isWindows ? `${command}.cmd` : command, args, {
+/**
+ * A probe that could not run at all is reported as `unavailable`, and carries
+ * whether retrying could help. Retries exist for the seconds right after a
+ * publish, and a registry timeout or a 5xx is exactly what they are for --
+ * treating every unavailability as fatal would spend the retry budget on
+ * nothing. A missing executable, by contrast, will still be missing in 30s.
+ */
+function unavailable(message, { permanent = false } = {}) {
+  return { unavailable: message, permanent };
+}
+
+function npm(args) {
+  const result = spawnSync(isWindows ? 'npm.cmd' : 'npm', args, {
     cwd: repoRoot,
     encoding: 'utf8',
-    // A hung registry or SSH prompt should fail the check, not wedge CI.
-    timeout: 60_000,
+    // A hung registry should fail the check, not wedge CI.
+    timeout: 30_000,
+    // `npm` on Windows is a .cmd shim, which CreateProcess cannot execute
+    // directly -- it needs a shell. scripts/ci-package.mjs does the same.
+    // One consequence: a missing npm surfaces as a non-zero exit from the
+    // shell rather than ENOENT, so on Windows it is retried before failing.
+    shell: isWindows,
   });
   if (result.error?.code === 'ENOENT') {
-    return { unavailable: `${command} is not on PATH` };
+    return unavailable('npm is not on PATH', { permanent: true });
+  }
+  if (result.error) {
+    return unavailable(`npm ${args[0]} did not complete: ${result.error.code}`);
   }
   return {
     status: result.status,
@@ -96,7 +115,7 @@ function run(command, args) {
   };
 }
 
-// `git` is not a .cmd shim on Windows the way `npm` is.
+// `git` is a real executable on Windows, so unlike npm it needs no shell.
 function git(args) {
   const result = spawnSync('git', args, {
     cwd: repoRoot,
@@ -104,7 +123,10 @@ function git(args) {
     timeout: 60_000,
   });
   if (result.error?.code === 'ENOENT') {
-    return { unavailable: 'git is not on PATH' };
+    return unavailable('git is not on PATH', { permanent: true });
+  }
+  if (result.error) {
+    return unavailable(`git ${args[0]} did not complete: ${result.error.code}`);
   }
   return {
     status: result.status,
@@ -119,14 +141,26 @@ function remoteTagExists(version) {
   const result = git(['ls-remote', '--tags', 'origin', ref]);
   if (result.unavailable) return result;
   if (result.status !== 0) {
-    return { unavailable: `git ls-remote failed: ${result.stderr || 'unknown error'}` };
+    // Transport failures live here -- worth retrying.
+    return unavailable(`git ls-remote failed: ${result.stderr || 'unknown error'}`);
   }
   return { found: result.stdout.includes(ref) };
 }
 
 /** What does the registry hold for this package? */
 function npmView(pkg, field) {
-  const result = run('npm', ['view', pkg, field, '--json']);
+  // npm retries fetches twice by default with a five-minute timeout each. That
+  // would nest its backoff inside this script's own retry loop and let a single
+  // unreachable registry hold a CI job for many minutes. Fail the request fast
+  // and let the loop here be the only thing that retries.
+  const result = npm([
+    'view',
+    pkg,
+    field,
+    '--json',
+    '--fetch-retries=0',
+    '--fetch-timeout=15000',
+  ]);
   if (result.unavailable) return result;
   if (result.status !== 0) {
     // A version that does not exist yet is the expected "not released" answer,
@@ -134,13 +168,36 @@ function npmView(pkg, field) {
     if (/E404|not found|is not in this registry/i.test(result.stderr)) {
       return { missing: true };
     }
-    return { unavailable: `npm view failed: ${result.stderr.split('\n')[0] || 'unknown error'}` };
+    // 5xx, ETIMEDOUT, ECONNRESET, and a missing npm on Windows all land here.
+    return unavailable(`npm view failed: ${result.stderr.split('\n')[0] || 'unknown error'}`);
   }
   try {
     return { value: JSON.parse(result.stdout) };
   } catch {
-    return { unavailable: `npm view returned unparseable JSON for ${pkg} ${field}` };
+    return unavailable(`npm view returned unparseable JSON for ${pkg} ${field}`, {
+      permanent: true,
+    });
   }
+}
+
+// ---------------------------------------------------------------------------
+// Retry policy
+// ---------------------------------------------------------------------------
+
+/**
+ * Is another attempt worth making?
+ *
+ * A verified release stops the loop, and so does a probe that can never
+ * succeed on this machine. Everything else -- a dist-tag that has not become
+ * visible yet, a registry 5xx, a git transport hiccup -- is what the retries
+ * exist for, since this runs seconds after a publish.
+ *
+ * @param {{ok: boolean, blocked: ?string, blockedPermanent: boolean}} result
+ */
+export function shouldRetry(result) {
+  if (result.ok) return false;
+  if (result.blocked && result.blockedPermanent) return false;
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -188,10 +245,17 @@ function attempt(name, version, channel) {
   const report = [];
   let ok = true;
   let blocked = null;
+  let blockedPermanent = false;
+
+  const note = (probe) => {
+    if (blocked) return;
+    blocked = probe.unavailable;
+    blockedPermanent = probe.permanent === true;
+  };
 
   const tag = remoteTagExists(version);
   if (tag.unavailable) {
-    blocked = tag.unavailable;
+    note(tag);
   } else if (tag.found) {
     report.push(line(PASS, `git tag v${version} on origin`));
   } else {
@@ -203,7 +267,7 @@ function attempt(name, version, channel) {
 
   const published = npmView(`${name}@${version}`, 'version');
   if (published.unavailable) {
-    blocked = blocked || published.unavailable;
+    note(published);
   } else if (published.missing) {
     ok = false;
     report.push(line(FAIL, `npm has ${name}@${version}`, 'version not published'));
@@ -213,7 +277,7 @@ function attempt(name, version, channel) {
 
   const tags = npmView(name, 'dist-tags');
   if (tags.unavailable) {
-    blocked = blocked || tags.unavailable;
+    note(tags);
   } else if (tags.missing) {
     ok = false;
     report.push(line(FAIL, `dist-tag ${channel}`, 'package has no dist-tags'));
@@ -229,7 +293,10 @@ function attempt(name, version, channel) {
     }
   }
 
-  return { ok, blocked, report };
+  // A blocked probe is not a pass. Leaving `ok` true here would let the retry
+  // loop exit on its `result.ok` check before ever reaching the retry logic,
+  // which is the whole reason the retries exist.
+  return { ok: ok && !blocked, blocked, blockedPermanent, report };
 }
 
 async function main() {
@@ -263,10 +330,13 @@ async function main() {
   let result;
   for (let attemptNo = 0; attemptNo <= opts.retries; attemptNo += 1) {
     result = attempt(name, version, channel);
-    if (result.blocked || result.ok) break;
+    if (!shouldRetry(result)) break;
     if (attemptNo < opts.retries) {
+      const why = result.blocked
+        ? `a probe could not run (${result.blocked})`
+        : 'not visible yet';
       process.stdout.write(
-        `  ...not visible yet, retrying in ${opts.delay}ms ` +
+        `  ...${why}, retrying in ${opts.delay}ms ` +
           `(${attemptNo + 1}/${opts.retries})\n`,
       );
       // eslint-disable-next-line no-await-in-loop

--- a/scripts/release-verify.mjs
+++ b/scripts/release-verify.mjs
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+/**
+ * Release verification.
+ *
+ * Answers one question: did the version currently in `package.json` actually
+ * ship? Merging a `chore(release):` commit publishes nothing -- publish.yml
+ * triggers on `push: tags: v*` and on nothing else -- so a bumped version next
+ * to a written CHANGELOG entry reads exactly like a release and need not be
+ * one. 1.11.0 and 1.12.0 were both lost that way. See docs/DEVELOPMENT.md
+ * section 6.
+ *
+ * Every check queries a remote on purpose. A tag that exists only on the
+ * machine running this script is the precise failure being guarded against,
+ * and `git tag --list` would report it as present.
+ *
+ * Usage:
+ *   node scripts/release-verify.mjs [--retries N] [--delay MS]
+ *
+ * Exit codes:
+ *   0  the version is tagged on the remote and live on npm under its channel
+ *   1  it is not (the report says which check failed and what to do)
+ *   3  a check could not be run at all (git/npm missing, network down)
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// ---------------------------------------------------------------------------
+// Channel derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the npm dist-tag a version publishes to.
+ *
+ * This mirrors the bash in `.github/workflows/publish.yml` ("Verify tag matches
+ * package version") deliberately and must not drift from it: that job is the
+ * gate that decides whether a build moves `latest`, and this script exists to
+ * confirm the gate did what was intended. The two are covered by the same
+ * table of cases in release-verify.test.mjs.
+ *
+ * Build metadata is stripped first. It is not part of the pre-release, yet it
+ * may itself contain a hyphen (`1.2.3+build-next` is a *stable* release) or
+ * trail one (`1.2.3-next+build`).
+ *
+ * @param {string} version - e.g. "1.13.0", "1.13.0-next.0".
+ * @returns {{channel: string, prerelease: boolean} | {error: string}}
+ */
+export function deriveChannel(version) {
+  const precedence = String(version).split('+')[0];
+  const dash = precedence.indexOf('-');
+
+  if (dash === -1) {
+    return { channel: 'latest', prerelease: false };
+  }
+
+  const channel = precedence.slice(dash + 1).split('.')[0];
+
+  // npm refuses any dist-tag that parses as a SemVer range, so "x" and "v1"
+  // are rejected here rather than after a publish has already happened.
+  if (
+    !/^[a-z][a-z0-9-]*$/.test(channel) ||
+    channel === 'latest' ||
+    channel === 'x' ||
+    /^v[0-9]+$/.test(channel)
+  ) {
+    return { error: `unusable pre-release channel '${channel}'` };
+  }
+
+  return { channel, prerelease: true };
+}
+
+// ---------------------------------------------------------------------------
+// Remote probes
+// ---------------------------------------------------------------------------
+
+const isWindows = process.platform === 'win32';
+
+function run(command, args) {
+  const result = spawnSync(isWindows ? `${command}.cmd` : command, args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    // A hung registry or SSH prompt should fail the check, not wedge CI.
+    timeout: 60_000,
+  });
+  if (result.error?.code === 'ENOENT') {
+    return { unavailable: `${command} is not on PATH` };
+  }
+  return {
+    status: result.status,
+    stdout: (result.stdout || '').trim(),
+    stderr: (result.stderr || '').trim(),
+  };
+}
+
+// `git` is not a .cmd shim on Windows the way `npm` is.
+function git(args) {
+  const result = spawnSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
+  if (result.error?.code === 'ENOENT') {
+    return { unavailable: 'git is not on PATH' };
+  }
+  return {
+    status: result.status,
+    stdout: (result.stdout || '').trim(),
+    stderr: (result.stderr || '').trim(),
+  };
+}
+
+/** Does `refs/tags/v<version>` exist on `origin`? */
+function remoteTagExists(version) {
+  const ref = `refs/tags/v${version}`;
+  const result = git(['ls-remote', '--tags', 'origin', ref]);
+  if (result.unavailable) return result;
+  if (result.status !== 0) {
+    return { unavailable: `git ls-remote failed: ${result.stderr || 'unknown error'}` };
+  }
+  return { found: result.stdout.includes(ref) };
+}
+
+/** What does the registry hold for this package? */
+function npmView(pkg, field) {
+  const result = run('npm', ['view', pkg, field, '--json']);
+  if (result.unavailable) return result;
+  if (result.status !== 0) {
+    // A version that does not exist yet is the expected "not released" answer,
+    // not a broken check -- distinguish it from a registry that is unreachable.
+    if (/E404|not found|is not in this registry/i.test(result.stderr)) {
+      return { missing: true };
+    }
+    return { unavailable: `npm view failed: ${result.stderr.split('\n')[0] || 'unknown error'}` };
+  }
+  try {
+    return { value: JSON.parse(result.stdout) };
+  } catch {
+    return { unavailable: `npm view returned unparseable JSON for ${pkg} ${field}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+const PASS = 'pass';
+const FAIL = 'FAIL';
+
+function line(state, label, detail) {
+  return `  [${state}] ${label}${detail ? ` -- ${detail}` : ''}`;
+}
+
+async function sleep(ms) {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function parseArgs(argv) {
+  const opts = { retries: 0, delay: 5000 };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--retries') {
+      opts.retries = Number.parseInt(argv[i + 1], 10);
+      i += 1;
+    } else if (arg === '--delay') {
+      opts.delay = Number.parseInt(argv[i + 1], 10);
+      i += 1;
+    } else {
+      return { error: `unknown argument '${arg}'` };
+    }
+  }
+  if (!Number.isInteger(opts.retries) || opts.retries < 0) {
+    return { error: '--retries expects a non-negative integer' };
+  }
+  if (!Number.isInteger(opts.delay) || opts.delay < 0) {
+    return { error: '--delay expects a non-negative integer (milliseconds)' };
+  }
+  return opts;
+}
+
+/** One full pass over the three checks. */
+function attempt(name, version, channel) {
+  const report = [];
+  let ok = true;
+  let blocked = null;
+
+  const tag = remoteTagExists(version);
+  if (tag.unavailable) {
+    blocked = tag.unavailable;
+  } else if (tag.found) {
+    report.push(line(PASS, `git tag v${version} on origin`));
+  } else {
+    ok = false;
+    report.push(
+      line(FAIL, `git tag v${version} on origin`, 'not found, so publish.yml never ran'),
+    );
+  }
+
+  const published = npmView(`${name}@${version}`, 'version');
+  if (published.unavailable) {
+    blocked = blocked || published.unavailable;
+  } else if (published.missing) {
+    ok = false;
+    report.push(line(FAIL, `npm has ${name}@${version}`, 'version not published'));
+  } else {
+    report.push(line(PASS, `npm has ${name}@${version}`));
+  }
+
+  const tags = npmView(name, 'dist-tags');
+  if (tags.unavailable) {
+    blocked = blocked || tags.unavailable;
+  } else if (tags.missing) {
+    ok = false;
+    report.push(line(FAIL, `dist-tag ${channel}`, 'package has no dist-tags'));
+  } else {
+    const actual = tags.value?.[channel];
+    if (actual === version) {
+      report.push(line(PASS, `dist-tag ${channel} -> ${version}`));
+    } else {
+      ok = false;
+      report.push(
+        line(FAIL, `dist-tag ${channel}`, `points at ${actual ?? 'nothing'}, expected ${version}`),
+      );
+    }
+  }
+
+  return { ok, blocked, report };
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.error) {
+    process.stderr.write(`release-verify: ${opts.error}\n`);
+    process.exit(1);
+  }
+
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'));
+  } catch (err) {
+    process.stderr.write(`release-verify: cannot read package.json -- ${err.message}\n`);
+    process.exit(3);
+  }
+
+  const { name, version } = pkg;
+  const derived = deriveChannel(version);
+  if (derived.error) {
+    process.stderr.write(
+      `release-verify: ${version} cannot publish -- ${derived.error}.\n` +
+        'publish.yml would reject this version rather than guess a channel.\n',
+    );
+    process.exit(1);
+  }
+
+  const { channel } = derived;
+  process.stdout.write(`${name} ${version} -> dist-tag ${channel}\n`);
+
+  let result;
+  for (let attemptNo = 0; attemptNo <= opts.retries; attemptNo += 1) {
+    result = attempt(name, version, channel);
+    if (result.blocked || result.ok) break;
+    if (attemptNo < opts.retries) {
+      process.stdout.write(
+        `  ...not visible yet, retrying in ${opts.delay}ms ` +
+          `(${attemptNo + 1}/${opts.retries})\n`,
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(opts.delay);
+    }
+  }
+
+  if (result.blocked) {
+    process.stderr.write(`release-verify: could not complete the check -- ${result.blocked}\n`);
+    process.exit(3);
+  }
+
+  process.stdout.write(`${result.report.join('\n')}\n`);
+
+  if (result.ok) {
+    process.stdout.write(`\n${version} is released.\n`);
+    process.exit(0);
+  }
+
+  process.stdout.write(
+    `\n${version} is NOT released.\n` +
+      `Tag the release commit and push it:  git tag v${version} && git push origin v${version}\n` +
+      'If the tag is already on origin, publish.yml ran and failed -- read its log.\n' +
+      'Never re-tag an older release commit to catch up: publish.yml reads the version\n' +
+      "out of the commit being tagged, so the job passes its own check and pushes that\n" +
+      'commit\'s build to its channel. Roll missed content into the next version instead.\n',
+  );
+  process.exit(1);
+}
+
+// Only run when invoked as a command. Without this guard, importing
+// deriveChannel -- which the tests do -- would execute the whole CLI, hit the
+// network, and exit the test runner before a single case had run.
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  await main();
+}

--- a/scripts/release-verify.test.mjs
+++ b/scripts/release-verify.test.mjs
@@ -1,0 +1,113 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { deriveChannel } from './release-verify.mjs';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('deriveChannel', () => {
+  // Each row is the contract publish.yml documents in its own comments.
+  const stable = [
+    ['1.13.0', 'a plain version publishes to latest'],
+    ['1.12.0', 'the version that was never tagged is still a stable one'],
+    ['0.1.0', 'pre-1.0 versions are stable too'],
+  ];
+
+  for (const [version, why] of stable) {
+    test(`${version} -> latest (${why})`, () => {
+      assert.deepEqual(deriveChannel(version), { channel: 'latest', prerelease: false });
+    });
+  }
+
+  const prerelease = [
+    ['1.12.0-next.0', 'next'],
+    ['1.13.0-next.0', 'next'],
+    ['1.12.0-rc.1', 'rc'],
+    ['1.12.0-beta.7', 'beta'],
+    ['1.2.3-next', 'next', 'no counter is still a channel'],
+    ['1.2.3-next-beta.0', 'next-beta', 'a hyphen inside the identifier survives'],
+  ];
+
+  for (const [version, channel, why] of prerelease) {
+    test(`${version} -> ${channel}${why ? ` (${why})` : ''}`, () => {
+      assert.deepEqual(deriveChannel(version), { channel, prerelease: true });
+    });
+  }
+
+  // Build metadata is not part of precedence, and is stripped before the
+  // pre-release identifier is read. It can itself contain or trail a hyphen,
+  // which is exactly where a naive split gets this wrong.
+  test('1.2.3+build-next is stable, not a next release', () => {
+    assert.deepEqual(deriveChannel('1.2.3+build-next'), { channel: 'latest', prerelease: false });
+  });
+
+  test('1.2.3-next+build keeps its channel after metadata is stripped', () => {
+    assert.deepEqual(deriveChannel('1.2.3-next+build'), { channel: 'next', prerelease: true });
+  });
+
+  // An identifier that cannot be read as a channel is a hard stop. Publishing
+  // it would either move `latest` by accident or be refused by npm after the
+  // gates have already run.
+  const rejected = [
+    ['1.2.3-', 'empty identifier'],
+    ['1.2.3-NEXT.0', 'uppercase'],
+    ['1.2.3-0.1', 'purely numeric'],
+    ['1.2.3-1', 'numeric'],
+    ['1.2.3-latest', 'literally latest, which would move the default channel'],
+    ['1.2.3-x', 'npm parses x as a version range'],
+    ['1.2.3-v1', 'npm parses v1 as a version range'],
+    ['1.2.3-v12', 'any v-then-digits parses as a range'],
+  ];
+
+  for (const [version, why] of rejected) {
+    test(`${version} is refused (${why})`, () => {
+      const result = deriveChannel(version);
+      assert.ok(result.error, `expected ${version} to be refused, got ${JSON.stringify(result)}`);
+      assert.match(result.error, /unusable pre-release channel/);
+    });
+  }
+
+  test('a rejected version never reports a channel to publish to', () => {
+    for (const [version] of rejected) {
+      const result = deriveChannel(version);
+      assert.equal(result.channel, undefined);
+      assert.equal(result.prerelease, undefined);
+    }
+  });
+});
+
+// deriveChannel is a deliberate mirror of the bash in publish.yml. Nothing
+// stops the two from drifting except this: if the workflow's conditions are
+// edited, this fails and points at the copy that also needs updating.
+describe('publish.yml has not drifted from deriveChannel', () => {
+  const workflow = readFileSync(join(repoRoot, '.github/workflows/publish.yml'), 'utf8');
+
+  const required = [
+    ['precedence="${version%%+*}"', 'strips build metadata before reading the identifier'],
+    ['channel="${precedence#*-}"', 'takes everything after the first hyphen'],
+    ['channel="${channel%%.*}"', 'then everything before the first dot'],
+    ['^[a-z][a-z0-9-]*$', 'shape of an acceptable channel'],
+    ['[ "$channel" = "latest" ]', 'refuses to move the default channel'],
+    ['[ "$channel" = "x" ]', 'refuses the x range'],
+    ['^v[0-9]+$', 'refuses v-then-digits ranges'],
+  ];
+
+  for (const [snippet, why] of required) {
+    test(`still present: ${why}`, () => {
+      assert.ok(
+        workflow.includes(snippet),
+        `publish.yml no longer contains ${JSON.stringify(snippet)}. ` +
+          'If the channel rules changed there, update deriveChannel in ' +
+          'scripts/release-verify.mjs to match, then update this test.',
+      );
+    });
+  }
+
+  test('the workflow still triggers only on v* tags', () => {
+    // The whole premise of release-verify is that nothing else publishes.
+    assert.match(workflow, /on:\s*\n\s*push:\s*\n\s*tags:\s*\n\s*-\s*["']v\*["']/);
+  });
+});

--- a/scripts/release-verify.test.mjs
+++ b/scripts/release-verify.test.mjs
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { deriveChannel } from './release-verify.mjs';
+import { deriveChannel, shouldRetry } from './release-verify.mjs';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -109,5 +109,43 @@ describe('publish.yml has not drifted from deriveChannel', () => {
   test('the workflow still triggers only on v* tags', () => {
     // The whole premise of release-verify is that nothing else publishes.
     assert.match(workflow, /on:\s*\n\s*push:\s*\n\s*tags:\s*\n\s*-\s*["']v\*["']/);
+  });
+});
+
+describe('shouldRetry', () => {
+  test('a verified release stops the loop', () => {
+    assert.equal(shouldRetry({ ok: true, blocked: null, blockedPermanent: false }), false);
+  });
+
+  test('a probe that can never run stops the loop', () => {
+    // Spending a 30s retry budget waiting for git to appear on PATH helps
+    // nobody, and the exit code says "could not check", not "not released".
+    assert.equal(
+      shouldRetry({ ok: false, blocked: 'git is not on PATH', blockedPermanent: true }),
+      false,
+    );
+  });
+
+  test('a registry or transport hiccup is retried', () => {
+    assert.equal(
+      shouldRetry({ ok: false, blocked: 'npm view failed: ECONNREFUSED', blockedPermanent: false }),
+      true,
+    );
+  });
+
+  test('a dist-tag that has not appeared yet is retried', () => {
+    // The ordinary case seconds after a publish: every probe ran, the answer
+    // is just not visible on the registry yet.
+    assert.equal(shouldRetry({ ok: false, blocked: null, blockedPermanent: false }), true);
+  });
+
+  test('a blocked attempt is never reported as ok', () => {
+    // The bug this guards: `ok` was left true when a probe was blocked, so the
+    // loop exited on its ok check before the retry logic could ever run.
+    assert.equal(
+      shouldRetry({ ok: true, blocked: 'npm view failed: ECONNREFUSED', blockedPermanent: false }),
+      false,
+      'if this ever passes a blocked-but-ok result, attempt() has regressed',
+    );
   });
 });

--- a/scripts/release-verify.test.mjs
+++ b/scripts/release-verify.test.mjs
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { deriveChannel, shouldRetry } from './release-verify.mjs';
+import { deriveChannel, shouldRetry, REGISTRY } from './release-verify.mjs';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -109,6 +109,14 @@ describe('publish.yml has not drifted from deriveChannel', () => {
   test('the workflow still triggers only on v* tags', () => {
     // The whole premise of release-verify is that nothing else publishes.
     assert.match(workflow, /on:\s*\n\s*push:\s*\n\s*tags:\s*\n\s*-\s*["']v\*["']/);
+  });
+
+  test('the pinned registry is the one the workflow publishes to', () => {
+    // Verification must ask the registry the release actually went to. If these
+    // drift, a private mirror could report a failed public publish as a success.
+    const match = workflow.match(/registry-url:\s*["']([^"']+)["']/);
+    assert.ok(match, 'publish.yml no longer sets registry-url');
+    assert.equal(match[1].replace(/\/$/, ''), REGISTRY);
   });
 });
 


### PR DESCRIPTION
Follow-up to #60. That PR documented the check; this one runs it.

## Why a script and not just the doc

#60 told the reader to verify by hand that a release took effect. That is the same mechanism that lost 1.11.0 and 1.12.0 — it works only while someone remembers. So the check also runs as **publish.yml's last step**: a publish that does not take effect now turns the workflow red instead of passing quietly, which is exactly how both versions went unnoticed for a month.

## What it does

`npm run release:verify` reads the version from `package.json`, re-derives the dist-tag that version publishes to, and asserts three things:

- the `v<version>` tag reached `origin`
- npm holds that version
- the dist-tag actually points at it

Exit 0 released, exit 1 not — with the failing check named and a remedy. Exit 3 when a probe could not run at all (no git/npm, network down), kept distinct from a genuine "not released" so a broken check never reads as a clean bill of health.

Every probe queries a remote on purpose. A tag that exists only on the local machine is the precise failure being guarded against — the `git tag --list` trap Codex caught on #60.

Against the current tree:

```
lumina-wiki 1.13.0-next.0 -> dist-tag next
  [pass] git tag v1.13.0-next.0 on origin
  [pass] npm has lumina-wiki@1.13.0-next.0
  [pass] dist-tag next -> 1.13.0-next.0
```

And with the version bumped to an unreleased `1.99.0`, reproducing the 1.11.0/1.12.0 shape:

```
  [FAIL] git tag v1.99.0 on origin -- not found, so publish.yml never ran
  [FAIL] npm has lumina-wiki@1.99.0 -- version not published
  [FAIL] dist-tag latest -- points at 1.10.1, expected 1.99.0
```

That `points at 1.10.1` line is the diagnostic that would have exposed this months ago.

## The drift risk, and what holds it

`deriveChannel` mirrors the bash in publish.yml's "Verify tag matches package version" step. That is duplication of the gate deciding whether a build moves `latest`, so it is worth being explicit about: the two can drift.

Two things hold it. The tests cover the channel table on both sides — build metadata that contains a hyphen (`1.2.3+build-next` is *stable*) or trails one (`1.2.3-next+build`), plus every rejected identifier: empty, uppercase, numeric, literally `latest`, and the `x` / `v1` forms npm parses as ranges. And a second suite asserts publish.yml still contains each condition being mirrored, so editing the workflow's rules fails the suite and points at the copy that also needs updating.

Making publish.yml call this script for its own derivation would remove the duplication outright. I did not do it here — that is a refactor of the release-critical path, and it should not ride along with the change that introduces the script.

## Verified

| Check | Result |
|---|---|
| `test:catalog` (28 new cases) | 39 pass, 0 fail |
| `test:scripts` / `test:installer` | 530 / 377, 0 fail |
| `ci:package`, `ci:idempotency` | pass |
| `npm pack --dry-run` | `scripts/` absent, 117 files — none of this ships |
| publish.yml parses, new step is last | 10 steps |

`scripts/` is not in the `files` allowlist, so the zero-telemetry rule is untouched: nothing here runs on a user's machine.

## One defect worth recording

The first version of the script called `await main()` at module top level, so merely importing `deriveChannel` ran the whole CLI, hit the network, and exited the test runner before a single case ran — the suite reported "1 test pass" and looked fine. Caught by noticing the count was 1 rather than 28. Fixed with an invoked-directly guard, and the comment on that guard says why it exists.
